### PR TITLE
Pass in generic BetAmount to `place_bet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,16 @@ Execute `main.py` with optional arguments:
 
 ```bash
 % python main.py --help
-usage: main.py [-h] [--agent-type {langchain,autogen,always_yes}] [--auto-bet AUTO_BET]
+Usage: main.py [OPTIONS]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  --agent-type {langchain,autogen,always_yes}
-  --auto-bet AUTO_BET   If true, does not require user input to place the bet.
+  Picks one market and answers it, optionally placing a bet.
+
+Options:
+  --market-type [manifold|omen]   [default: MarketType.MANIFOLD]
+  --agent-type [langchain|autogen|always_yes|coin_flip|llamaindex|metagpt|crewai|custom_openai|custom_llama]
+                                  [default: AgentType.ALWAYS_YES]
+  --auto-bet / --no-auto-bet      [default: no-auto-bet]
+  --help                          Show this message and exit.
 ```
 
 ## Testing

--- a/agent.py
+++ b/agent.py
@@ -1,7 +1,6 @@
 import typer
 import time
 import logging
-import typing as t
 from decimal import Decimal
 from datetime import timedelta
 
@@ -9,10 +8,9 @@ import prediction_market_agent as pma
 from prediction_market_agent.tools.gtypes import xDai, Mana
 from prediction_market_agent.markets.all_markets import (
     MarketType,
+    get_bet_amount,
     get_binary_markets,
     place_bet,
-    omen,
-    manifold,
 )
 from prediction_market_agent.agents.abstract import AbstractAgent
 from prediction_market_agent.agents.all_agents import AgentType, get_agent
@@ -49,8 +47,7 @@ def main(
 
         place_bet(
             market=agent_market.original_market,
-            amount_mana=Mana(amount),
-            amount_xdai=xDai(amount),
+            amount=get_bet_amount(amount, market_type),
             outcome=answer,
             keys=keys,
             omen_auto_deposit=True,

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from prediction_market_agent.agents.all_agents import AgentType, get_agent
 from prediction_market_agent.tools.gtypes import xDai, Mana
 from prediction_market_agent.markets.all_markets import (
     MarketType,
+    get_bet_amount,
     omen,
     manifold,
     get_binary_markets,
@@ -51,8 +52,7 @@ def main(
         )
         place_bet(
             market=market.original_market,
-            amount_mana=Mana(amount),
-            amount_xdai=xDai(amount),
+            amount=get_bet_amount(amount, market_type),
             outcome=result,
             keys=keys,
             omen_auto_deposit=True,

--- a/prediction_market_agent/data_models/market_data_models.py
+++ b/prediction_market_agent/data_models/market_data_models.py
@@ -2,6 +2,7 @@ import typing as t
 from pydantic import BaseModel
 from web3 import Web3
 from web3.types import Wei
+from prediction_market_agent.markets.all_markets import Currency
 from prediction_market_agent.tools.gtypes import (
     USD,
     HexAddress,
@@ -23,7 +24,7 @@ class AgentMarket(BaseModel):
     id: str
     question: str
     outcomes: list[str]
-    bet_amount_currency: str
+    bet_amount_currency: Currency
     original_market: t.Union["OmenMarket", "ManifoldMarket"]
 
 
@@ -32,7 +33,7 @@ class OmenMarket(BaseModel):
     https://aiomen.eth.limo
     """
 
-    BET_AMOUNT_CURRENCY: t.ClassVar[str] = "xDai"
+    BET_AMOUNT_CURRENCY: Currency = Currency.xDai
 
     id: HexAddress
     title: str
@@ -107,7 +108,7 @@ class ManifoldMarket(BaseModel):
     https://manifold.markets
     """
 
-    BET_AMOUNT_CURRENCY: t.ClassVar[str] = "Mana"
+    BET_AMOUNT_CURRENCY: Currency = Currency.Mana
 
     id: str
     question: str

--- a/prediction_market_agent/data_models/market_data_models.py
+++ b/prediction_market_agent/data_models/market_data_models.py
@@ -44,7 +44,7 @@ class OmenMarket(BaseModel):
     https://aiomen.eth.limo
     """
 
-    BET_AMOUNT_CURRENCY: Currency = Currency.xDai
+    BET_AMOUNT_CURRENCY: t.ClassVar[Currency] = Currency.xDai
 
     id: HexAddress
     title: str

--- a/prediction_market_agent/data_models/market_data_models.py
+++ b/prediction_market_agent/data_models/market_data_models.py
@@ -1,8 +1,9 @@
+from decimal import Decimal
+from enum import Enum
 import typing as t
 from pydantic import BaseModel
 from web3 import Web3
 from web3.types import Wei
-from prediction_market_agent.markets.all_markets import Currency
 from prediction_market_agent.tools.gtypes import (
     USD,
     HexAddress,
@@ -13,6 +14,16 @@ from prediction_market_agent.tools.gtypes import (
     xDai,
 )
 from datetime import datetime
+
+
+class Currency(str, Enum):
+    xDai = "xDai"
+    Mana = "Mana"
+
+
+class BetAmount(BaseModel):
+    amount: Decimal
+    currency: Currency
 
 
 class AgentMarket(BaseModel):

--- a/prediction_market_agent/markets/all_markets.py
+++ b/prediction_market_agent/markets/all_markets.py
@@ -1,8 +1,22 @@
+from decimal import Decimal
 import typing as t
 from enum import Enum
+
+from pydantic import BaseModel
 from prediction_market_agent.markets import manifold, omen
+from prediction_market_agent.tools.gtypes import Mana
 from prediction_market_agent.tools.utils import should_not_happen, check_not_none
 from prediction_market_agent.utils import APIKeys
+
+
+class Currency(str, Enum):
+    xDai = "xDai"
+    Mana = "Mana"
+
+
+class BetAmount(BaseModel):
+    amount: Decimal
+    currency: Currency
 
 
 class MarketType(str, Enum):
@@ -10,25 +24,31 @@ class MarketType(str, Enum):
     OMEN = "omen"
 
 
+def get_bet_amount(amount: Decimal, market_type: MarketType) -> BetAmount:
+    if market_type == MarketType.OMEN:
+        return BetAmount(amount=amount, currency=Currency.xDai)
+    elif market_type == MarketType.MANIFOLD:
+        return BetAmount(amount=amount, currency=Currency.Mana)
+    else:
+        raise ValueError(f"Unknown market type: {market_type}")
+
+
 @t.overload
 def get_binary_markets(
     market_type: t.Literal[MarketType.MANIFOLD],
-) -> list[manifold.ManifoldMarket]:
-    ...
+) -> list[manifold.ManifoldMarket]: ...
 
 
 @t.overload
 def get_binary_markets(
     market_type: t.Literal[MarketType.OMEN],
-) -> list[omen.OmenMarket]:
-    ...
+) -> list[omen.OmenMarket]: ...
 
 
 @t.overload
 def get_binary_markets(
     market_type: MarketType,
-) -> t.Union[list[manifold.ManifoldMarket], list[omen.OmenMarket]]:
-    ...
+) -> t.Union[list[manifold.ManifoldMarket], list[omen.OmenMarket]]: ...
 
 
 def get_binary_markets(
@@ -47,25 +67,29 @@ def place_bet(
     outcome: bool,
     keys: APIKeys,
     omen_auto_deposit: bool,
-    amount_mana: t.Optional[manifold.Mana] = None,
-    amount_xdai: t.Optional[omen.xDai] = None,
+    amount: BetAmount,
 ) -> None:
-    manifold.place_bet(
-        amount=check_not_none(amount_mana),
-        market_id=market.id,
-        outcome=outcome,
-        api_key=check_not_none(keys.manifold),
-    ) if isinstance(
-        market, manifold.ManifoldMarket
-    ) else omen.binary_omen_buy_outcome_tx(
-        amount=check_not_none(amount_xdai),
-        from_address=check_not_none(keys.bet_from_address),
-        from_private_key=check_not_none(keys.bet_from_private_key),
-        market=market,
-        binary_outcome=outcome,
-        auto_deposit=omen_auto_deposit,
-    ) if isinstance(
-        market, omen.OmenMarket
-    ) else should_not_happen(
-        f"Unknown market {market}."
-    )
+    if isinstance(market, manifold.ManifoldMarket):
+        if amount.currency != Currency.Mana:
+            raise ValueError(f"Manifold bets are made in Mana. Got {amount.currency}.")
+        amount_mana = Mana(amount.amount)
+        manifold.place_bet(
+            amount=check_not_none(amount_mana),
+            market_id=market.id,
+            outcome=outcome,
+            api_key=check_not_none(keys.manifold),
+        )
+    elif isinstance(market, omen.OmenMarket):
+        if amount.currency != Currency.xDai:
+            raise ValueError(f"Omen bets are made in xDai. Got {amount.currency}.")
+        amount_xdai = Mana(amount.amount)
+        omen.binary_omen_buy_outcome_tx(
+            amount=check_not_none(amount_xdai),
+            from_address=check_not_none(keys.bet_from_address),
+            from_private_key=check_not_none(keys.bet_from_private_key),
+            market=market,
+            binary_outcome=outcome,
+            auto_deposit=omen_auto_deposit,
+        )
+    else:
+        should_not_happen(f"Unknown market {market}.")

--- a/prediction_market_agent/markets/all_markets.py
+++ b/prediction_market_agent/markets/all_markets.py
@@ -26,19 +26,22 @@ def get_bet_amount(amount: Decimal, market_type: MarketType) -> BetAmount:
 @t.overload
 def get_binary_markets(
     market_type: t.Literal[MarketType.MANIFOLD],
-) -> list[manifold.ManifoldMarket]: ...
+) -> list[manifold.ManifoldMarket]:
+    ...
 
 
 @t.overload
 def get_binary_markets(
     market_type: t.Literal[MarketType.OMEN],
-) -> list[omen.OmenMarket]: ...
+) -> list[omen.OmenMarket]:
+    ...
 
 
 @t.overload
 def get_binary_markets(
     market_type: MarketType,
-) -> t.Union[list[manifold.ManifoldMarket], list[omen.OmenMarket]]: ...
+) -> t.Union[list[manifold.ManifoldMarket], list[omen.OmenMarket]]:
+    ...
 
 
 def get_binary_markets(

--- a/prediction_market_agent/markets/all_markets.py
+++ b/prediction_market_agent/markets/all_markets.py
@@ -1,22 +1,12 @@
 from decimal import Decimal
 import typing as t
 from enum import Enum
+from prediction_market_agent.data_models.market_data_models import BetAmount, Currency
 
-from pydantic import BaseModel
 from prediction_market_agent.markets import manifold, omen
-from prediction_market_agent.tools.gtypes import Mana
+from prediction_market_agent.tools.gtypes import Mana, xDai
 from prediction_market_agent.tools.utils import should_not_happen, check_not_none
 from prediction_market_agent.utils import APIKeys
-
-
-class Currency(str, Enum):
-    xDai = "xDai"
-    Mana = "Mana"
-
-
-class BetAmount(BaseModel):
-    amount: Decimal
-    currency: Currency
 
 
 class MarketType(str, Enum):
@@ -82,7 +72,7 @@ def place_bet(
     elif isinstance(market, omen.OmenMarket):
         if amount.currency != Currency.xDai:
             raise ValueError(f"Omen bets are made in xDai. Got {amount.currency}.")
-        amount_xdai = Mana(amount.amount)
+        amount_xdai = xDai(amount.amount)
         omen.binary_omen_buy_outcome_tx(
             amount=check_not_none(amount_xdai),
             from_address=check_not_none(keys.bet_from_address),


### PR DESCRIPTION
I prefer `place_bet` taking a single required `amount` arg, and then handling the conversion to the correct currency, as apposed to taking optional `amount`s in all the possible currencies it could support.