### PR TITLE
Make KnownOutcomeAgent cheaper for unknown outcomes

### DIFF
--- a/prediction_market_agent/agents/known_outcome_agent/benchmark.py
+++ b/prediction_market_agent/agents/known_outcome_agent/benchmark.py
@@ -32,7 +32,9 @@ class QuestionWithKnownOutcome(BaseModel):
             id=self.question,
             question=self.question,
             p_yes=Probability(
-                self.result.to_p_yes() if self.result != Result.UNKNOWN else 0.5
+                self.result.to_p_yes()
+                if self.result != Result.KNOWN_UNKNOWABLE
+                else 0.5
             ),
             volume=None,
             created_time=None,
@@ -60,7 +62,8 @@ class KnownOutcomeAgent(AbstractBenchmarkedAgent):
             question=market_question,
             max_tries=self.max_tries,
         )
-        if answer.result == Result.UNKNOWN:
+        print(f"Answered {market_question=} with {answer.result=}, {answer.reasoning=}")
+        if not answer.has_known_result():
             return Prediction(
                 is_predictable=False,
                 outcome_prediction=None,
@@ -127,17 +130,17 @@ if __name__ == "__main__":
         ),
         QuestionWithKnownOutcome(
             question="Will Lewis Hamilton win the 2024/2025 F1 drivers champtionship?",
-            result=Result.UNKNOWN,
+            result=Result.KNOWN_UNKNOWABLE,
             notes="Outcome is uncertain.",
         ),
         QuestionWithKnownOutcome(
             question="Will the cost of grain in the Spain increase by 20% by 19 July 2024?",
-            result=Result.UNKNOWN,
+            result=Result.KNOWN_UNKNOWABLE,
             notes="Outcome is uncertain.",
         ),
         QuestionWithKnownOutcome(
             question="Will over 360 pople have died while climbing Mount Everest by 1st Jan 2028?",
-            result=Result.UNKNOWN,
+            result=Result.KNOWN_UNKNOWABLE,
             notes="Outcome is uncertain.",
         ),
     ]

--- a/prediction_market_agent/agents/known_outcome_agent/deploy.py
+++ b/prediction_market_agent/agents/known_outcome_agent/deploy.py
@@ -10,6 +10,7 @@ from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import BetAmount, Currency
 from prediction_market_agent_tooling.markets.markets import MarketType
 from prediction_market_agent_tooling.tools.utils import (
+    check_not_none,
     get_current_git_commit_sha,
     get_current_git_url,
 )
@@ -51,7 +52,7 @@ class DeployableKnownOutcomeAgent(DeployableAgent):
         N_TO_PICK = 5
         if all(market.close_time for market in picked_markets):
             picked_markets = sorted(
-                picked_markets, key=lambda market: market.close_time
+                picked_markets, key=lambda market: check_not_none(market.close_time)
             )[:N_TO_PICK]
         else:
             picked_markets = random.sample(

--- a/prediction_market_agent/agents/known_outcome_agent/known_outcome_agent.py
+++ b/prediction_market_agent/agents/known_outcome_agent/known_outcome_agent.py
@@ -14,8 +14,21 @@ from prediction_market_agent.tools.web_search.tavily import web_search
 
 
 class Result(str, Enum):
+    """
+    With perfect information, a binary question should have one of three answers:
+    YES, NO, or KNOWN_UNKNOWABLE:
+
+    - Will the sun rise tomorrow? YES
+    - Will the Bradley Cooper win best actor at the 2024 oscars by 01/04/2024? NO (because the event has already happened, and Cillian Murphy won)
+    - Will over 360 pople have died while climbing Mount Everest by 1st Jan 2028? KNOWN_UNKNOWABLE (because the closing date has not happened yet, and we cannot predict the outcome with reasoanable certainty)
+
+    but since the agent's information is based on web scraping, and is therefore
+    imperfect, we allow it to defer answering definitively via the UNKNOWN result.
+    """
+
     YES = "YES"
     NO = "NO"
+    KNOWN_UNKNOWABLE = "KNOWN_UNKNOWABLE"
     UNKNOWN = "UNKNOWN"
 
     def to_p_yes(self) -> float:
@@ -34,13 +47,17 @@ class Result(str, Enum):
         else:
             raise ValueError("Unexpected result")
 
+    @property
+    def is_known(self) -> bool:
+        return self in [Result.YES, Result.NO]
+
 
 class Answer(BaseModel):
     result: Result
     reasoning: str
 
-    def has_known_outcome(self) -> bool:
-        return self.result is not Result.UNKNOWN
+    def has_known_result(self) -> bool:
+        return self.result.is_known
 
 
 HAS_QUESTION_HAPPENED_IN_THE_PAST_PROMPT = """
@@ -72,7 +89,7 @@ For example, if the question is:
 
 You might generate the following search query:
 
-"Champions League semi-finals draw 2024"
+"Champions League semi-finals draw 2025"
 
 Answer with the single prompt only, and nothing else.
 """
@@ -100,20 +117,25 @@ following fields:
 
 where <REASONING> is a free text field containing your reasoning, and <RESULT>
 is a multiple-choice field containing only one of 'YES' (if the answer to the
-question is yes), 'NO' (if the answer to the question is no), or 'UNKNOWN' if
-you are unable to answer the question with a reasonable degree of certainty from
-the web-scraped information. Your answer should only contain this json string,
-and nothing else.
+question is yes), 'NO' (if the answer to the question is no), 'KNOWN_UNKNOWABLE'
+(if we can answer with a reasonable degree of certainty from the web-scraped
+information that the question cannot be answered either way for the time being),
+or 'UNKNOWN' if you are unable to give one of the above answers with a
+reasonable degree of certainty from the web-scraped information. Your answer
+should only contain this json string, and nothing else.
 
 If the question is of the format: "Will X happen by Y?" then the result should
 be as follows:
 - If X has already happened, the result is 'YES'.
 - If not-X has already happened, the result is 'NO'.
 - If X has been announced to happen after Y, result 'NO'.
+- If you are confident that none of the above are the case, and the result will only be knowable in the future, or not at all, the result is 'KNOWN_UNKNOWABLE'.
 - Otherwise, the result is 'UNKNOWN'.
 
-If the question is of the format: "Will X happen on Y?"
+If the question is of the format: "Will X happen on Y?" then the result should
+be as follows:
 - If something has happened that necessarily prevents X from happening on Y, the result is 'NO'.
+- If you are confident that nothing has happened that necessarily prevents X from happening on Y, the result is 'KNOWN_UNKNOWN'.
 - Otherwise, the result is 'UNKNOWN'.
 """
 

--- a/prediction_market_agent/agents/known_outcome_agent/known_outcome_agent.py
+++ b/prediction_market_agent/agents/known_outcome_agent/known_outcome_agent.py
@@ -135,7 +135,7 @@ be as follows:
 If the question is of the format: "Will X happen on Y?" then the result should
 be as follows:
 - If something has happened that necessarily prevents X from happening on Y, the result is 'NO'.
-- If you are confident that nothing has happened that necessarily prevents X from happening on Y, the result is 'KNOWN_UNKNOWN'.
+- If you are confident that nothing has happened that necessarily prevents X from happening on Y, the result is 'KNOWN_UNKNOWABLE'.
 - Otherwise, the result is 'UNKNOWN'.
 """
 


### PR DESCRIPTION
TL;DR Before, markets without a known answer cost ~$0.40 in LLM credits, now they cost $0.05.

KnownOutcomeAgent predictions currently cost ~$0.03 for markets with known outcomes, but ~$0.40 for markets with unknown outcomes(!!). This makes them too expensive to run on a large number of markets.

Currently we work around this by disallowing the agent from betting on markets concerning events happening in the future (via `has_question_event_happened_in_the_past` for filtering markets). This is overly restrictive in that it filters out most of the Omen markets we care about betting on!
```
>>> q = "Will the Francis Scott Key Bridge in Baltimore be operational again by April 4th, 2024?"
>>> has_question_event_happened_in_the_past(model="gpt-4-1106-preview", question=q)
False
```

This PR removes this constraint and instead makes it a lot cheaper to research markets whose answer is not knowable, by allowing the agent to decide if a question is unknowable early, without having to exhaustively search and invoke the LLM until max retries is reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Expanded the `Result` options to better handle scenarios with unknowable outcomes.
- **Enhancements**
    - Improved market selection logic in prediction models, favoring markets with the earliest closing times or selecting randomly if no closing times are available.
- **Refactor**
    - Renamed a method for clarity in determining known results.
- **Style**
    - Updated prompt messages to align with the new outcome categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->