### PR TITLE
Make microchain Functions (somewhat) market-type agnostic

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/functions.py
+++ b/prediction_market_agent/agents/microchain_agent/functions.py
@@ -275,7 +275,6 @@ MARKET_FUNCTIONS: list[type[MarketFunction]] = [
     BuyNo,
     SellYes,
     SellNo,
-    # BalanceToOutcomes,
     GetWalletBalance,
     GetUserPositions,
 ]

--- a/prediction_market_agent/agents/microchain_agent/functions.py
+++ b/prediction_market_agent/agents/microchain_agent/functions.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from eth_utils import to_checksum_address
 from microchain import Function
+from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import BetAmount, Currency
 from prediction_market_agent_tooling.markets.markets import MarketType
@@ -20,7 +21,6 @@ from prediction_market_agent_tooling.tools.balances import get_balances
 
 from prediction_market_agent.agents.microchain_agent.utils import (
     MicroMarket,
-    fetch_public_key_from_env,
     get_binary_market_from_question,
     get_binary_markets,
     get_market_token_balance,
@@ -118,7 +118,7 @@ class GetBalance(MarketFunction):
 class BuyTokens(MarketFunction):
     def __init__(self, market_type: MarketType, outcome: str):
         self.outcome = outcome
-        self.user_address = fetch_public_key_from_env()
+        self.user_address = APIKeys().bet_from_address
         super().__init__(market_type=market_type)
 
     @property

--- a/prediction_market_agent/agents/microchain_agent/microchain_agent.py
+++ b/prediction_market_agent/agents/microchain_agent/microchain_agent.py
@@ -1,17 +1,20 @@
 import os
 
 from dotenv import load_dotenv
-from functions import ALL_FUNCTIONS
+from functions import MARKET_FUNCTIONS, MISC_FUNCTIONS
 from microchain import LLM, Agent, Engine, OpenAIChatGenerator
 from microchain.functions import Reasoning, Stop
+from prediction_market_agent_tooling.markets.markets import MarketType
 
 load_dotenv()
 
 engine = Engine()
 engine.register(Reasoning())
 engine.register(Stop())
-for function in ALL_FUNCTIONS:
+for function in MISC_FUNCTIONS:
     engine.register(function())
+for function in MARKET_FUNCTIONS:
+    engine.register(function(market_type=MarketType.OMEN))
 
 generator = OpenAIChatGenerator(
     model="gpt-4-turbo-preview",

--- a/prediction_market_agent/agents/microchain_agent/utils.py
+++ b/prediction_market_agent/agents/microchain_agent/utils.py
@@ -1,5 +1,3 @@
-import os
-
 from eth_typing import ChecksumAddress
 from prediction_market_agent_tooling.markets.agent_market import (
     AgentMarket,
@@ -18,8 +16,7 @@ from prediction_market_agent_tooling.markets.omen.omen_subgraph_handler import (
     OmenSubgraphHandler,
 )
 from prediction_market_agent_tooling.tools.hexbytes_custom import HexBytes
-from prediction_market_agent_tooling.tools.web3_utils import private_key_to_public_key
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 from web3.types import Wei
 
 
@@ -75,13 +72,6 @@ def get_market_token_balance(
     position_as_int = int(position_for_index_set.id.hex(), 16)
     balance = OmenConditionalTokenContract().balanceOf(user_address, position_as_int)
     return balance
-
-
-def fetch_public_key_from_env() -> ChecksumAddress:
-    private_key = os.environ.get("BET_FROM_PRIVATE_KEY")
-    if private_key is None:
-        raise EnvironmentError("Could not load private key using env var")
-    return private_key_to_public_key(SecretStr(private_key))
 
 
 def get_yes_outcome(market_type: MarketType) -> str:

--- a/prediction_market_agent/agents/microchain_agent/utils.py
+++ b/prediction_market_agent/agents/microchain_agent/utils.py
@@ -43,7 +43,11 @@ def get_binary_markets(market_type: MarketType) -> list[AgentMarket]:
     cls = market_type.market_class
     markets: list[AgentMarket] = cls.get_binary_markets(
         filter_by=FilterBy.OPEN,
-        sort_by=SortBy.CLOSING_SOONEST,
+        sort_by=(
+            SortBy.NONE
+            if market_type == MarketType.POLYMARKET
+            else SortBy.CLOSING_SOONEST
+        ),
         limit=5,
     )
     return markets

--- a/tests/agents/test_microchain.py
+++ b/tests/agents/test_microchain.py
@@ -1,7 +1,4 @@
-import typing as t
-
 import pytest
-from dotenv import load_dotenv
 from eth_typing import HexAddress, HexStr
 from prediction_market_agent_tooling.markets.markets import MarketType
 from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
@@ -26,12 +23,6 @@ from tests.utils import RUN_PAID_TESTS
 
 REPLICATOR_ADDRESS = "0x993DFcE14768e4dE4c366654bE57C21D9ba54748"
 AGENT_0_ADDRESS = "0x2DD9f5678484C1F59F97eD334725858b938B4102"
-
-
-@pytest.fixture(scope="session", autouse=True)
-def before_all_tests() -> t.Generator[None, None, None]:
-    load_dotenv()
-    yield None
 
 
 # TODO investigate why this fails for polymarket https://github.com/gnosis/prediction-market-agent/issues/62

--- a/tests/agents/test_microchain.py
+++ b/tests/agents/test_microchain.py
@@ -34,7 +34,8 @@ def before_all_tests() -> t.Generator[None, None, None]:
     yield None
 
 
-@pytest.mark.parametrize("market_type", [MarketType.OMEN])
+# TODO investigate why this fails for polymarket https://github.com/gnosis/prediction-market-agent/issues/62
+@pytest.mark.parametrize("market_type", [MarketType.OMEN, MarketType.MANIFOLD])
 def test_get_markets(market_type: MarketType) -> None:
     get_markets = GetMarkets(market_type=market_type)
     assert len(get_markets()) > 0

--- a/tests/agents/test_microchain.py
+++ b/tests/agents/test_microchain.py
@@ -3,6 +3,7 @@ import typing as t
 import pytest
 from dotenv import load_dotenv
 from eth_typing import HexAddress, HexStr
+from prediction_market_agent_tooling.markets.markets import MarketType
 from prediction_market_agent_tooling.markets.omen.omen import OmenAgentMarket
 from prediction_market_agent_tooling.markets.omen.omen_subgraph_handler import (
     OmenSubgraphHandler,
@@ -18,8 +19,8 @@ from prediction_market_agent.agents.microchain_agent.functions import (
     GetWalletBalance,
 )
 from prediction_market_agent.agents.microchain_agent.utils import (
-    get_omen_binary_markets,
-    get_omen_market_token_balance,
+    get_binary_markets,
+    get_market_token_balance,
 )
 from tests.utils import RUN_PAID_TESTS
 
@@ -33,39 +34,46 @@ def before_all_tests() -> t.Generator[None, None, None]:
     yield None
 
 
-def test_get_markets() -> None:
-    get_markets = GetMarkets()
+@pytest.mark.parametrize("market_type", [MarketType.OMEN])
+def test_get_markets(market_type: MarketType) -> None:
+    get_markets = GetMarkets(market_type=market_type)
     assert len(get_markets()) > 0
 
 
 @pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
-def test_buy_yes() -> None:
-    market = get_omen_binary_markets()[0]
-    buy_yes = BuyYes()
+@pytest.mark.parametrize("market_type", [MarketType.OMEN])
+def test_buy_yes(market_type: MarketType) -> None:
+    market = get_binary_markets(market_type=market_type)[0]
+    buy_yes = BuyYes(market_type=market_type)
     print(buy_yes(market.question, 0.0001))
 
 
 @pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
-def test_buy_no() -> None:
-    market = get_omen_binary_markets()[0]
-    buy_yes = BuyNo()
+@pytest.mark.parametrize("market_type", [MarketType.OMEN])
+def test_buy_no(market_type: MarketType) -> None:
+    market = get_binary_markets(market_type=market_type)[0]
+    buy_yes = BuyNo(market_type=market_type)
     print(buy_yes(market.question, 0.0001))
 
 
-def test_replicator_has_balance_gt_0() -> None:
-    balance = GetWalletBalance()(REPLICATOR_ADDRESS)
+@pytest.mark.parametrize("market_type", [MarketType.OMEN])
+def test_replicator_has_balance_gt_0(market_type: MarketType) -> None:
+    balance = GetWalletBalance(market_type=market_type)(REPLICATOR_ADDRESS)
     assert balance > 0
 
 
-def test_agent_0_has_bet_on_market() -> None:
-    user_positions = GetUserPositions()(AGENT_0_ADDRESS)
+@pytest.mark.parametrize("market_type", [MarketType.OMEN])
+def test_agent_0_has_bet_on_market(market_type: MarketType) -> None:
+    user_positions = GetUserPositions(market_type=market_type)(AGENT_0_ADDRESS)
     # Assert 3 conditionIds are included
     expected_condition_ids = [
         HexBytes("0x9c7711bee0902cc8e6838179058726a7ba769cc97d4d0ea47b31370d2d7a117b"),
         HexBytes("0xe2bf80af2a936cdabeef4f511620a2eec46f1caf8e75eb5dc189372367a9154c"),
         HexBytes("0x3f8153364001b26b983dd92191a084de8230f199b5ad0b045e9e1df61089b30d"),
     ]
-    unique_condition_ids = sum([u.position.conditionIds for u in user_positions], [])
+    unique_condition_ids: HexBytes = sum(
+        [u.position.conditionIds for u in user_positions], [HexBytes("")]
+    )
     assert set(expected_condition_ids).issubset(unique_condition_ids)
 
 
@@ -77,7 +85,7 @@ def test_balance_for_user_in_market() -> None:
     )  # yes/no
     market = subgraph_handler.get_omen_market(market_id)
     omen_agent_market = OmenAgentMarket.from_data_model(market)
-    balance_yes = get_omen_market_token_balance(
+    balance_yes = get_market_token_balance(
         user_address=Web3.to_checksum_address(user_address),
         market_condition_id=omen_agent_market.condition.id,
         market_index_set=market.condition.index_sets[0],
@@ -85,7 +93,7 @@ def test_balance_for_user_in_market() -> None:
 
     assert balance_yes == 1959903969410997
 
-    balance_no = get_omen_market_token_balance(
+    balance_no = get_market_token_balance(
         user_address=Web3.to_checksum_address(user_address),
         market_condition_id=omen_agent_market.condition.id,
         market_index_set=market.condition.index_sets[1],

--- a/tests/agents/test_microchain.py
+++ b/tests/agents/test_microchain.py
@@ -71,8 +71,8 @@ def test_agent_0_has_bet_on_market(market_type: MarketType) -> None:
         HexBytes("0xe2bf80af2a936cdabeef4f511620a2eec46f1caf8e75eb5dc189372367a9154c"),
         HexBytes("0x3f8153364001b26b983dd92191a084de8230f199b5ad0b045e9e1df61089b30d"),
     ]
-    unique_condition_ids: HexBytes = sum(
-        [u.position.conditionIds for u in user_positions], [HexBytes("")]
+    unique_condition_ids: list[HexBytes] = sum(
+        [u.position.conditionIds for u in user_positions], []
     )
     assert set(expected_condition_ids).issubset(unique_condition_ids)
 


### PR DESCRIPTION
Subclass microchain `Function` class with `MarketFunction` that takes `MarketType`, to differentiate behaviour of functions.

This way the abstractions in microchain_agent/functions.py don't have any market-specific code in them (i.e. no 'Omen' or 'Maninfold' imports from PMAT). There are few left over after the merge of https://github.com/gnosis/prediction-market-agent/pull/59, but the idea is there.