### PR TITLE
Add deployment for prediction-offline mech

### DIFF
--- a/prediction_market_agent/agents/mech_agent/deploy.py
+++ b/prediction_market_agent/agents/mech_agent/deploy.py
@@ -42,3 +42,9 @@ class DeployablePredictionOnlineAgent(DeployableMechAgentBase):
     def load(self) -> None:
         self.local = True
         self.tool = MechTool.PREDICTION_ONLINE
+
+
+class DeployablePredictionOfflineAgent(DeployableMechAgentBase):
+    def load(self) -> None:
+        self.local = True
+        self.tool = MechTool.PREDICTION_OFFLINE

--- a/prediction_market_agent/run_agent.py
+++ b/prediction_market_agent/run_agent.py
@@ -16,6 +16,7 @@ from prediction_market_agent.agents.known_outcome_agent.deploy import (
     DeployableKnownOutcomeAgent,
 )
 from prediction_market_agent.agents.mech_agent.deploy import (
+    DeployablePredictionOfflineAgent,
     DeployablePredictionOnlineAgent,
 )
 from prediction_market_agent.agents.replicate_to_omen_agent.deploy import (
@@ -33,6 +34,7 @@ class RunnableAgent(str, Enum):
     knownoutcome = "knownoutcome"
     # Mechs
     mech_prediction_online = "mech_prediction-online"
+    mech_prediction_offline = "mech_prediction-offline"
 
 
 RUNNABLE_AGENTS = {
@@ -41,6 +43,7 @@ RUNNABLE_AGENTS = {
     RunnableAgent.think_thoroughly: DeployableThinkThoroughlyAgent,
     RunnableAgent.knownoutcome: DeployableKnownOutcomeAgent,
     RunnableAgent.mech_prediction_online: DeployablePredictionOnlineAgent,
+    RunnableAgent.mech_prediction_offline: DeployablePredictionOfflineAgent,
 }
 
 

--- a/prediction_market_agent/tools/mech/utils.py
+++ b/prediction_market_agent/tools/mech/utils.py
@@ -32,6 +32,7 @@ def saved_str_to_tmpfile(s: str) -> t.Iterator[str]:
 class MechTool(str, Enum):
     PREDICTION_WITH_RESEARCH_REPORT = "prediction-with-research-conservative"
     PREDICTION_ONLINE = "prediction-online"
+    PREDICTION_OFFLINE = "prediction-offline"
 
 
 def mech_request(question: str, mech_tool: MechTool) -> OutcomePrediction:
@@ -68,7 +69,10 @@ def mech_request_local(question: str, mech_tool: MechTool) -> OutcomePrediction:
                 "tavily": keys.tavily_api_key.get_secret_value(),
             },
         )
-    elif mech_tool == MechTool.PREDICTION_ONLINE:
+    elif (
+        mech_tool == MechTool.PREDICTION_ONLINE
+        or mech_tool == MechTool.PREDICTION_OFFLINE
+    ):
         response = prediction_request.run(
             tool=mech_tool.value,
             prompt=question,

--- a/prediction_market_agent/tools/mech/utils.py
+++ b/prediction_market_agent/tools/mech/utils.py
@@ -69,10 +69,7 @@ def mech_request_local(question: str, mech_tool: MechTool) -> OutcomePrediction:
                 "tavily": keys.tavily_api_key.get_secret_value(),
             },
         )
-    elif (
-        mech_tool == MechTool.PREDICTION_ONLINE
-        or mech_tool == MechTool.PREDICTION_OFFLINE
-    ):
+    elif mech_tool in [MechTool.PREDICTION_ONLINE, MechTool.PREDICTION_OFFLINE]:
         response = prediction_request.run(
             tool=mech_tool.value,
             prompt=question,


### PR DESCRIPTION
Tested locally with `python prediction_market_agent/run_agent.py mech_prediction-offline omen`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced offline prediction capabilities to enhance the prediction market agent's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->