### PR TITLE
Add deployment for prediction-on/offline-sme mechs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2226,13 +2226,13 @@ protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4
 
 [[package]]
 name = "google-cloud-secret-manager"
-version = "2.19.0"
+version = "2.20.0"
 description = "Google Cloud Secret Manager API client library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-cloud-secret-manager-2.19.0.tar.gz", hash = "sha256:bb918435835a14eb94785f4d4d9087bdcf1b6de306432d7edaa7d62e7f780c30"},
-    {file = "google_cloud_secret_manager-2.19.0-py2.py3-none-any.whl", hash = "sha256:7dd9ad9ab3e70f9a7fbac432938b702ba23bce1207e9bda86463b6d6b1f5cdbb"},
+    {file = "google-cloud-secret-manager-2.20.0.tar.gz", hash = "sha256:a086a7413aaf4fffbd1c4fe9229ef0ce9bcf48f5a8df5b449c4a32deb5a2cfde"},
+    {file = "google_cloud_secret_manager-2.20.0-py2.py3-none-any.whl", hash = "sha256:c20bf22e59d220c51aa84a1db3411b14b83aa71f788fae8d273c03a4bf3e77ed"},
 ]
 
 [package.dependencies]

--- a/prediction_market_agent/agents/mech_agent/deploy.py
+++ b/prediction_market_agent/agents/mech_agent/deploy.py
@@ -48,3 +48,15 @@ class DeployablePredictionOfflineAgent(DeployableMechAgentBase):
     def load(self) -> None:
         self.local = True
         self.tool = MechTool.PREDICTION_OFFLINE
+
+
+class DeployablePredictionOnlineSMEAgent(DeployableMechAgentBase):
+    def load(self) -> None:
+        self.local = True
+        self.tool = MechTool.PREDICTION_ONLINE_SME
+
+
+class DeployablePredictionOfflineSMEAgent(DeployableMechAgentBase):
+    def load(self) -> None:
+        self.local = True
+        self.tool = MechTool.PREDICTION_OFFLINE_SME

--- a/prediction_market_agent/agents/mech_agent/deploy.py
+++ b/prediction_market_agent/agents/mech_agent/deploy.py
@@ -1,0 +1,44 @@
+import random
+import typing as t
+
+from prediction_market_agent_tooling.benchmark.utils import OutcomePrediction
+from prediction_market_agent_tooling.deploy.agent import DeployableAgent
+from prediction_market_agent_tooling.markets.agent_market import AgentMarket
+
+from prediction_market_agent.tools.mech.utils import (
+    MechTool,
+    mech_request,
+    mech_request_local,
+)
+
+
+class DeployableMechAgentBase(DeployableAgent):
+    def load(self) -> None:
+        self.tool: MechTool | None = None
+        self.local: bool | None = None
+
+    @property
+    def prediction_fn(self) -> t.Callable[[str, MechTool], OutcomePrediction]:
+        if self.local is None:
+            raise ValueError("Local mode not set")
+
+        return mech_request_local if self.local else mech_request
+
+    def pick_markets(self, markets: t.Sequence[AgentMarket]) -> t.Sequence[AgentMarket]:
+        # We simply pick 5 random markets to bet on
+        markets = list(markets)
+        random.shuffle(markets)
+        return markets
+
+    def answer_binary_market(self, market: AgentMarket) -> bool:
+        if self.tool is None:
+            raise ValueError("Tool not set")
+
+        result: OutcomePrediction = self.prediction_fn(market.question, self.tool)
+        return True if result.p_yes >= 0.5 else False
+
+
+class DeployablePredictionOnlineAgent(DeployableMechAgentBase):
+    def load(self) -> None:
+        self.local = True
+        self.tool = MechTool.PREDICTION_ONLINE

--- a/prediction_market_agent/agents/mech_agent/deploy.py
+++ b/prediction_market_agent/agents/mech_agent/deploy.py
@@ -42,3 +42,9 @@ class DeployablePredictionOnlineAgent(DeployableMechAgentBase):
     def load(self) -> None:
         self.local = True
         self.tool = MechTool.PREDICTION_ONLINE
+
+
+class DeployablePredictionOfflineAgent(DeployableMechAgentBase):
+    def load(self) -> None:
+        self.local = True
+        self.tool = MechTool.PREDICTION_OFFLINE

--- a/prediction_market_agent/run_agent.py
+++ b/prediction_market_agent/run_agent.py
@@ -16,6 +16,7 @@ from prediction_market_agent.agents.known_outcome_agent.deploy import (
     DeployableKnownOutcomeAgent,
 )
 from prediction_market_agent.agents.mech_agent.deploy import (
+    DeployablePredictionOfflineAgent,
     DeployablePredictionOnlineAgent,
 )
 from prediction_market_agent.agents.replicate_to_omen_agent.deploy import (
@@ -33,6 +34,7 @@ class RunnableAgent(str, Enum):
     knownoutcome = "knownoutcome"
     # Mechs
     mech_prediction_online = "mech_prediction-online"
+    mech_prediction_offline = "mech_prediction-offline"
 
 
 RUNNABLE_AGENTS = {
@@ -41,6 +43,7 @@ RUNNABLE_AGENTS = {
     RunnableAgent.think_thoroughly: DeployableThinkThoroughlyAgent,
     RunnableAgent.knownoutcome: DeployableKnownOutcomeAgent,
     RunnableAgent.mech_prediction_online: DeployablePredictionOnlineAgent,
+    RunnableAgent.mech_prediction_offline: DeployablePredictionOfflineAgent,
 }
 
 

--- a/prediction_market_agent/run_agent.py
+++ b/prediction_market_agent/run_agent.py
@@ -17,7 +17,9 @@ from prediction_market_agent.agents.known_outcome_agent.deploy import (
 )
 from prediction_market_agent.agents.mech_agent.deploy import (
     DeployablePredictionOfflineAgent,
+    DeployablePredictionOfflineSMEAgent,
     DeployablePredictionOnlineAgent,
+    DeployablePredictionOnlineSMEAgent,
 )
 from prediction_market_agent.agents.replicate_to_omen_agent.deploy import (
     DeployableReplicateToOmenAgent,
@@ -35,6 +37,8 @@ class RunnableAgent(str, Enum):
     # Mechs
     mech_prediction_online = "mech_prediction-online"
     mech_prediction_offline = "mech_prediction-offline"
+    mech_prediction_online_sme = "mech_prediction-online-sme"
+    mech_prediction_offline_sme = "mech_prediction-offline-sme"
 
 
 RUNNABLE_AGENTS = {
@@ -44,6 +48,8 @@ RUNNABLE_AGENTS = {
     RunnableAgent.knownoutcome: DeployableKnownOutcomeAgent,
     RunnableAgent.mech_prediction_online: DeployablePredictionOnlineAgent,
     RunnableAgent.mech_prediction_offline: DeployablePredictionOfflineAgent,
+    RunnableAgent.mech_prediction_online_sme: DeployablePredictionOnlineSMEAgent,
+    RunnableAgent.mech_prediction_offline_sme: DeployablePredictionOfflineSMEAgent,
 }
 
 

--- a/prediction_market_agent/run_agent.py
+++ b/prediction_market_agent/run_agent.py
@@ -15,6 +15,9 @@ from prediction_market_agent.agents.coinflip_agent.deploy import DeployableCoinF
 from prediction_market_agent.agents.known_outcome_agent.deploy import (
     DeployableKnownOutcomeAgent,
 )
+from prediction_market_agent.agents.mech_agent.deploy import (
+    DeployablePredictionOnlineAgent,
+)
 from prediction_market_agent.agents.replicate_to_omen_agent.deploy import (
     DeployableReplicateToOmenAgent,
 )
@@ -28,6 +31,8 @@ class RunnableAgent(str, Enum):
     replicate_to_omen = "replicate_to_omen"
     think_thoroughly = "think_thoroughly"
     knownoutcome = "knownoutcome"
+    # Mechs
+    mech_prediction_online = "mech_prediction-online"
 
 
 RUNNABLE_AGENTS = {
@@ -35,6 +40,7 @@ RUNNABLE_AGENTS = {
     RunnableAgent.replicate_to_omen: DeployableReplicateToOmenAgent,
     RunnableAgent.think_thoroughly: DeployableThinkThoroughlyAgent,
     RunnableAgent.knownoutcome: DeployableKnownOutcomeAgent,
+    RunnableAgent.mech_prediction_online: DeployablePredictionOnlineAgent,
 }
 
 

--- a/prediction_market_agent/tools/mech/utils.py
+++ b/prediction_market_agent/tools/mech/utils.py
@@ -32,6 +32,7 @@ def saved_str_to_tmpfile(s: str) -> t.Iterator[str]:
 class MechTool(str, Enum):
     PREDICTION_WITH_RESEARCH_REPORT = "prediction-with-research-conservative"
     PREDICTION_ONLINE = "prediction-online"
+    PREDICTION_OFFLINE = "prediction-offline"
 
 
 def mech_request(question: str, mech_tool: MechTool) -> OutcomePrediction:
@@ -68,7 +69,10 @@ def mech_request_local(question: str, mech_tool: MechTool) -> OutcomePrediction:
                 "tavily": keys.tavily_api_key.get_secret_value(),
             },
         )
-    elif mech_tool == MechTool.PREDICTION_ONLINE:
+    elif (
+        mech_tool == MechTool.PREDICTION_ONLINE
+        or mech_tool == MechTool.PREDICTION_OFFLINE
+    ):
         response = prediction_request.run(
             tool=mech_tool.value,
             prompt=question,

--- a/prediction_market_agent/tools/mech/utils.py
+++ b/prediction_market_agent/tools/mech/utils.py
@@ -8,6 +8,9 @@ from mech_client.interact import ConfirmationType, interact
 from prediction_market_agent_tooling.benchmark.utils import OutcomePrediction
 
 from prediction_market_agent.tools.mech.api_keys import MechAPIKeys
+from prediction_market_agent.tools.mech.mech.packages.nickcom007.customs.prediction_request_sme import (
+    prediction_request_sme,
+)
 from prediction_market_agent.tools.mech.mech.packages.polywrap.customs.prediction_with_research_report import (
     prediction_with_research_report,
 )
@@ -33,6 +36,8 @@ class MechTool(str, Enum):
     PREDICTION_WITH_RESEARCH_REPORT = "prediction-with-research-conservative"
     PREDICTION_ONLINE = "prediction-online"
     PREDICTION_OFFLINE = "prediction-offline"
+    PREDICTION_ONLINE_SME = "prediction-online-sme"
+    PREDICTION_OFFLINE_SME = "prediction-offline-sme"
 
 
 def mech_request(question: str, mech_tool: MechTool) -> OutcomePrediction:
@@ -69,11 +74,18 @@ def mech_request_local(question: str, mech_tool: MechTool) -> OutcomePrediction:
                 "tavily": keys.tavily_api_key.get_secret_value(),
             },
         )
-    elif (
-        mech_tool == MechTool.PREDICTION_ONLINE
-        or mech_tool == MechTool.PREDICTION_OFFLINE
-    ):
+    elif mech_tool in [MechTool.PREDICTION_ONLINE, MechTool.PREDICTION_OFFLINE]:
         response = prediction_request.run(
+            tool=mech_tool.value,
+            prompt=question,
+            api_keys={
+                "openai": keys.openai_api_key.get_secret_value(),
+                "google_api_key": keys.google_search_api_key.get_secret_value(),
+                "google_engine_id": keys.google_search_engine_id.get_secret_value(),
+            },
+        )
+    elif mech_tool in [MechTool.PREDICTION_ONLINE_SME, MechTool.PREDICTION_OFFLINE_SME]:
+        response = prediction_request_sme.run(
             tool=mech_tool.value,
             prompt=question,
             api_keys={


### PR DESCRIPTION
Tested locally with `python prediction_market_agent/run_agent.py mech_prediction-on/offline-sme omen`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new agent classes for online and offline SME predictions in the prediction market, enhancing the scope and accuracy of predictions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->