### PR TITLE
Fix mech-calling agents and test

### DIFF
--- a/prediction_market_agent/agents/mech_agent/deploy.py
+++ b/prediction_market_agent/agents/mech_agent/deploy.py
@@ -6,6 +6,7 @@ from prediction_market_agent_tooling.deploy.agent import DeployableAgent
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 
 from prediction_market_agent.tools.mech.utils import (
+    MechResponse,
     MechTool,
     mech_request,
     mech_request_local,
@@ -20,7 +21,7 @@ class DeployableMechAgentBase(DeployableAgent):
         self.local: bool | None = None
 
     @property
-    def prediction_fn(self) -> t.Callable[[str, MechTool], OutcomePrediction]:
+    def prediction_fn(self) -> t.Callable[[str, MechTool], MechResponse]:
         if self.local is None:
             raise ValueError("Local mode not set")
 
@@ -36,8 +37,14 @@ class DeployableMechAgentBase(DeployableAgent):
         if self.tool is None:
             raise ValueError("Tool not set")
 
-        result: OutcomePrediction = self.prediction_fn(market.question, self.tool)
-        return result
+        response: MechResponse = self.prediction_fn(market.question, self.tool)
+        outcome_prediction = OutcomePrediction(
+            decision=response.p_yes > 0.5,
+            p_yes=response.p_yes,
+            confidence=response.confidence,
+            info_utility=response.info_utility,
+        )
+        return outcome_prediction
 
 
 class DeployablePredictionOnlineAgent(DeployableMechAgentBase):

--- a/prediction_market_agent/agents/microchain_agent/functions.py
+++ b/prediction_market_agent/agents/microchain_agent/functions.py
@@ -1,7 +1,6 @@
 import typing as t
 
 from microchain import Function
-from prediction_market_agent_tooling.benchmark.utils import OutcomePrediction
 from prediction_market_agent_tooling.config import PrivateCredentials
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import Currency, TokenAmount
@@ -17,6 +16,7 @@ from prediction_market_agent.agents.microchain_agent.utils import (
     get_yes_outcome,
 )
 from prediction_market_agent.tools.mech.utils import (
+    MechResponse,
     MechTool,
     mech_request,
     mech_request_local,
@@ -106,7 +106,7 @@ class GetMarketProbability(MarketFunction):
 class PredictProbabilityForQuestionBase(MarketFunction):
     def __init__(
         self,
-        mech_request: t.Callable[[str, MechTool], OutcomePrediction],
+        mech_request: t.Callable[[str, MechTool], MechResponse],
         market_type: MarketType,
         mech_tool: MechTool = MechTool.PREDICTION_ONLINE,
     ) -> None:
@@ -128,8 +128,8 @@ class PredictProbabilityForQuestionBase(MarketFunction):
         question = self.market_type.market_class.get_binary_market(
             id=market_id
         ).question
-        result: OutcomePrediction = self.mech_request(question, self.mech_tool)
-        return str(result.p_yes)
+        response: MechResponse = self.mech_request(question, self.mech_tool)
+        return str(response.p_yes)
 
 
 class PredictProbabilityForQuestionRemote(PredictProbabilityForQuestionBase):

--- a/tests/mech/test_mech_local.py
+++ b/tests/mech/test_mech_local.py
@@ -1,15 +1,18 @@
 import pytest
-from prediction_market_agent_tooling.benchmark.utils import OutcomePrediction
 
-from prediction_market_agent.tools.mech.utils import MechTool, mech_request_local
+from prediction_market_agent.tools.mech.utils import (
+    MechResponse,
+    MechTool,
+    mech_request_local,
+)
 from tests.utils import RUN_PAID_TESTS
 
 
 @pytest.mark.skipif(not RUN_PAID_TESTS, reason="This test costs money to run.")
 @pytest.mark.parametrize("mech_tool", list(MechTool))
 def test_mech_local(mech_tool: MechTool) -> None:
-    result: OutcomePrediction = mech_request_local(
-        question="Is the sky blue?",
+    response: MechResponse = mech_request_local(
+        question="Will the sun rise tomorrow?",
         mech_tool=mech_tool,
     )
-    assert 0 <= result.p_yes <= 1
+    assert 0 <= response.p_yes <= 1


### PR DESCRIPTION
After PMAT changes from https://github.com/gnosis/prediction-market-agent-tooling/pull/220

`RUN_PAID_TESTS=1 python -m pytest tests/mech/test_mech_local.py` now passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the prediction market tools with a new response type, `MechResponse`, improving clarity and utility in predictions.
- **Bug Fixes**
  - Updated method return types and variable names across multiple modules to ensure consistency and clarity in handling predictions.
- **Tests**
  - Modified test scenarios to align with the new prediction response structure and updated test assertions to validate the probability of outcomes accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->