### PR TITLE
Various improvements and fixes for microchain agent

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/app.py
+++ b/prediction_market_agent/agents/microchain_agent/app.py
@@ -20,8 +20,10 @@ from prediction_market_agent_tooling.tools.costs import openai_costs
 from prediction_market_agent_tooling.tools.utils import check_not_none
 from streamlit_extras.bottom_container import bottom
 
-from prediction_market_agent.agents.microchain_agent.functions import MARKET_FUNCTIONS
-from prediction_market_agent.agents.microchain_agent.microchain_agent import build_agent
+from prediction_market_agent.agents.microchain_agent.microchain_agent import (
+    build_agent,
+    build_agent_functions,
+)
 from prediction_market_agent.agents.microchain_agent.utils import (
     get_balance,
     get_initial_history_length,
@@ -31,6 +33,7 @@ from prediction_market_agent.streamlit_utils import check_required_api_keys
 from prediction_market_agent.utils import APIKeys
 
 MARKET_TYPE = MarketType.OMEN
+ALLOW_STOP = False
 
 
 def run_agent(agent: Agent, iterations: int, model: str) -> None:
@@ -82,6 +85,16 @@ def display_new_history_callback(agent: Agent) -> None:
         st.chat_message(h["role"]).write(h["content"])
 
 
+def long_term_memory_is_initialized() -> bool:
+    return "long_term_memory" in st.session_state
+
+
+def maybe_initialize_long_term_memory() -> None:
+    # Initialize the db storage
+    if not long_term_memory_is_initialized():
+        st.session_state.long_term_memory = LongTermMemory("microchain-streamlit-app")
+
+
 def agent_is_initialized() -> bool:
     return "agent" in st.session_state
 
@@ -94,13 +107,11 @@ def save_last_turn_history_to_memory(agent: Agent) -> None:
 def maybe_initialize_agent(model: str) -> None:
     # Initialize the agent
     if not agent_is_initialized():
-        long_term_memory = LongTermMemory("microchain-streamlit-app")
-        st.session_state.long_term_memory = long_term_memory
         st.session_state.agent = build_agent(
             market_type=MARKET_TYPE,
             model=model,
-            allow_stop=False,
-            long_term_memory=long_term_memory,
+            allow_stop=ALLOW_STOP,
+            long_term_memory=st.session_state.long_term_memory,
         )
         st.session_state.agent.reset()
         st.session_state.agent.build_initial_messages()
@@ -110,10 +121,14 @@ def maybe_initialize_agent(model: str) -> None:
         st.session_state.agent.on_iteration_end = display_new_history_callback
 
 
-def get_market_function_bullet_point_list() -> str:
+def get_function_bullet_point_list() -> str:
     bullet_points = ""
-    for function in MARKET_FUNCTIONS:
-        bullet_points += f"  - {function.__name__}\n"
+    for function in build_agent_functions(
+        market_type=MARKET_TYPE,
+        long_term_memory=st.session_state.long_term_memory,
+        allow_stop=ALLOW_STOP,
+    ):
+        bullet_points += f"  - {function.__class__.__name__}\n"
     return bullet_points
 
 
@@ -125,6 +140,7 @@ st.set_page_config(
 st.title("Prediction Market Trader Agent")
 check_required_api_keys(["OPENAI_API_KEY", "BET_FROM_PRIVATE_KEY"])
 keys = APIKeys()
+maybe_initialize_long_term_memory()
 
 with st.sidebar:
     st.subheader("Agent Info:")
@@ -180,7 +196,7 @@ with st.expander(
         f"[{MARKET_TYPE}]({MARKET_TYPE.market_class.base_url}) prediction "
         f"market APIs:"
     )
-    st.markdown(get_market_function_bullet_point_list())
+    st.markdown(get_function_bullet_point_list())
 
 # Placeholder for the agent's history
 history_container = st.container()
@@ -216,6 +232,12 @@ with history_container:
             model=model,
         )
         save_last_turn_history_to_memory(st.session_state.agent)
+        # Run the agent after the user's reasoning
+        run_agent(
+            agent=st.session_state.agent,
+            iterations=int(iterations),
+            model=model,
+        )
     if run_agent_button:
         maybe_initialize_agent(model)
         run_agent(

--- a/prediction_market_agent/agents/microchain_agent/functions.py
+++ b/prediction_market_agent/agents/microchain_agent/functions.py
@@ -27,32 +27,6 @@ from prediction_market_agent.tools.mech.utils import (
 from prediction_market_agent.utils import APIKeys
 
 
-class Sum(Function):
-    @property
-    def description(self) -> str:
-        return "Use this function to compute the sum of two numbers"
-
-    @property
-    def example_args(self) -> list[float]:
-        return [2, 2]
-
-    def __call__(self, a: float, b: float) -> float:
-        return a + b
-
-
-class Product(Function):
-    @property
-    def description(self) -> str:
-        return "Use this function to compute the product of two numbers"
-
-    @property
-    def example_args(self) -> list[float]:
-        return [2, 2]
-
-    def __call__(self, a: float, b: float) -> float:
-        return a * b
-
-
 class MarketFunction(Function):
     def __init__(self, market_type: MarketType) -> None:
         self.market_type = market_type
@@ -366,11 +340,6 @@ class RememberPastLearnings(Function):
         # Get the last 24hrs of the agent's memory
         return self.long_term_memory.search(from_=utcnow() - timedelta(days=1))
 
-
-MISC_FUNCTIONS = [
-    Sum,
-    Product,
-]
 
 # Functions that interact with the prediction markets
 MARKET_FUNCTIONS: list[type[MarketFunction]] = [

--- a/prediction_market_agent/agents/microchain_agent/omen_functions.py
+++ b/prediction_market_agent/agents/microchain_agent/omen_functions.py
@@ -1,8 +1,10 @@
 from microchain import Function
+from prediction_market_agent_tooling.markets.markets import MarketType
 from prediction_market_agent_tooling.markets.omen.omen import (
     redeem_from_all_user_positions,
 )
 
+from prediction_market_agent.agents.microchain_agent.utils import get_balance
 from prediction_market_agent.utils import APIKeys
 
 
@@ -15,8 +17,19 @@ class RedeemWinningBets(Function):
     def example_args(self) -> list[str]:
         return []
 
-    def __call__(self) -> None:
+    def __call__(self) -> str:
+        prev_balance = get_balance(market_type=MarketType.OMEN)
         redeem_from_all_user_positions(APIKeys())
+        new_balance = get_balance(market_type=MarketType.OMEN)
+        currency = new_balance.currency.value
+        if redeemed_amount := new_balance.amount - prev_balance.amount > 0:
+            return (
+                f"Redeemed {redeemed_amount} {currency} in winnings. New "
+                f"balance: {new_balance.amount}{currency}."
+            )
+        return (
+            f"No winnings to redeem. Balance remains: {new_balance.amount}{currency}."
+        )
 
 
 # Functions that interact exclusively with Omen prediction markets

--- a/prediction_market_agent/agents/microchain_agent/utils.py
+++ b/prediction_market_agent/agents/microchain_agent/utils.py
@@ -54,9 +54,10 @@ def get_binary_markets(market_type: MarketType) -> list[AgentMarket]:
 def get_balance(market_type: MarketType) -> BetAmount:
     currency = market_type.market_class.currency
     if market_type == MarketType.OMEN:
-        # We focus solely on xDAI balance for now to avoid the agent having to wrap/unwrap xDAI.
+        balances = get_balances(APIKeys().bet_from_address)
+        total_balance = balances.xdai + balances.wxdai
         return BetAmount(
-            amount=get_balances(APIKeys().bet_from_address).xdai,
+            amount=total_balance,
             currency=currency,
         )
     else:

--- a/tests/agents/microchain/test_functions.py
+++ b/tests/agents/microchain/test_functions.py
@@ -7,7 +7,6 @@ from prediction_market_agent_tooling.markets.markets import MarketType
 
 from prediction_market_agent.agents.microchain_agent.functions import (
     MARKET_FUNCTIONS,
-    MISC_FUNCTIONS,
     BuyNo,
     BuyYes,
     GetBalance,
@@ -66,8 +65,6 @@ def test_engine_help(market_type: MarketType) -> None:
     engine = Engine()
     engine.register(Reasoning())
     engine.register(Stop())
-    for function in MISC_FUNCTIONS:
-        engine.register(function())
     for function in MARKET_FUNCTIONS:
         engine.register(function(market_type=market_type))
 


### PR DESCRIPTION
UI improvements:
- When the user hits enter after adding some reasoning, the agent executes immediatedly (saves an extra click on Run for the user)
- Remove misc functions `Sum` and `Product`. They aren't much use atm.
- Increase the verbosity of the redeem function. Before it returned None.


Fixes:
- `get_balance` should show both xdai and wxdai. Previously it was showing just xdai. If the agent placed a bet, it could show the balance not changing at all!
- Include all agent functions in dropdown list (see pic)

<img width="1135" alt="Screenshot 2024-05-17 at 15 44 12" src="https://github.com/gnosis/prediction-market-agent/assets/56087052/1581dfae-f643-4225-aacf-44fd7b53b597">

