### PR TITLE
Ignore tiny positions for microchain agent

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2182,13 +2182,13 @@ packaging = "*"
 
 [[package]]
 name = "faker"
-version = "25.9.1"
+version = "25.9.2"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-25.9.1-py3-none-any.whl", hash = "sha256:f1dc27dc8035cb7e97e96afbb5fe1305eed6aeea53374702cbac96acfe851626"},
-    {file = "Faker-25.9.1.tar.gz", hash = "sha256:0e1cf7a8d3c94de91a65ab1e9cf7050903efae1e97901f8e5924a9f45147ae44"},
+    {file = "Faker-25.9.2-py3-none-any.whl", hash = "sha256:7f8cbd179a7351648bea31f53d021a2bdfdeb59e9b830e121a635916615e0ecd"},
+    {file = "Faker-25.9.2.tar.gz", hash = "sha256:ca94843600a4089a91394023fef014bb41fee509f8c4beef1530018373e770fb"},
 ]
 
 [package.dependencies]
@@ -5516,13 +5516,13 @@ subdirectory = "plugins/aea-ledger-ethereum"
 
 [[package]]
 name = "openai"
-version = "1.35.3"
+version = "1.35.4"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.35.3-py3-none-any.whl", hash = "sha256:7b26544cef80f125431c073ffab3811d2421fbb9e30d3bd5c2436aba00b042d5"},
-    {file = "openai-1.35.3.tar.gz", hash = "sha256:d6177087f150b381d49499be782d764213fdf638d391b29ca692b84dd675a389"},
+    {file = "openai-1.35.4-py3-none-any.whl", hash = "sha256:894b79c485fae2df3a6b68ceb570730e5a480c08bccc32a412cf3be2d4eb1384"},
+    {file = "openai-1.35.4.tar.gz", hash = "sha256:b58a0d6257c5c86e85b9b2f43e6eed04ada616560df9da0dca6697d06845e7c8"},
 ]
 
 [package.dependencies]
@@ -6166,56 +6166,52 @@ test = ["coverage", "flake8", "freezegun (==0.3.15)", "mock (>=2.0.0)", "pylint"
 
 [[package]]
 name = "prediction-market-agent-tooling"
-version = "0.39.1"
+version = "0.39.3"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 optional = false
-python-versions = ">=3.10,<3.12"
-files = []
-develop = false
+python-versions = "<3.12,>=3.10"
+files = [
+    {file = "prediction_market_agent_tooling-0.39.3-py3-none-any.whl", hash = "sha256:d267f4ccb257bd1dd3d55630911bc4f980bd178a28a1d59b9c8030923e79e9fa"},
+    {file = "prediction_market_agent_tooling-0.39.3.tar.gz", hash = "sha256:363ac57c510e2a605dcf4c9453f682d6e40b9dfd3bdf7a30bed72101dc0b88f9"},
+]
 
 [package.dependencies]
-autoflake = "^2.2.1"
-base58 = "^2.1.1"
-cron-validator = "^1.0.8"
-eth-account = "^0.8.0"
-eth-typing = "^3.0.0"
-functions-framework = "^3.5.0"
-google-api-python-client = {version = "2.95.0", optional = true}
-google-cloud-functions = "^1.16.0"
-google-cloud-resource-manager = "^1.12.0"
-google-cloud-secret-manager = "^2.18.2"
-isort = "^5.13.2"
-langchain = {version = "^0.1.9", optional = true}
+autoflake = ">=2.2.1,<3.0.0"
+base58 = ">=2.1.1,<3.0.0"
+cron-validator = ">=1.0.8,<2.0.0"
+eth-account = ">=0.8.0,<0.9.0"
+eth-typing = ">=3.0.0,<4.0.0"
+functions-framework = ">=3.5.0,<4.0.0"
+google-api-python-client = {version = "2.95.0", optional = true, markers = "extra == \"google\""}
+google-cloud-functions = ">=1.16.0,<2.0.0"
+google-cloud-resource-manager = ">=1.12.0,<2.0.0"
+google-cloud-secret-manager = ">=2.18.2,<3.0.0"
+isort = ">=5.13.2,<6.0.0"
+langchain = {version = ">=0.1.9,<0.2.0", optional = true, markers = "extra == \"langchain\""}
 langchain-community = ">=0.0.19"
-langchain-openai = {version = "^0.0.5", optional = true}
-langfuse = "^2.27.1"
-loguru = "^0.7.2"
-numpy = "^1.26.4"
-prompt-toolkit = "^3.0.43"
-pydantic = "^2.6.1"
-pydantic-settings = "^2.1.0"
-safe-cli = "^1.0.0"
-safe-eth-py = "^6.0.0b14"
-scikit-learn = "^1.3.1"
-streamlit = "^1.31.0"
-subgrounds = "^1.9.1"
-tabulate = "^0.9.0"
-tqdm = "^4.66.2"
+langchain-openai = {version = ">=0.0.5,<0.0.6", optional = true, markers = "extra == \"langchain\""}
+langfuse = ">=2.27.1,<3.0.0"
+loguru = ">=0.7.2,<0.8.0"
+numpy = ">=1.26.4,<2.0.0"
+prompt-toolkit = ">=3.0.43,<4.0.0"
+pydantic = ">=2.6.1,<3.0.0"
+pydantic-settings = ">=2.1.0,<3.0.0"
+safe-cli = ">=1.0.0,<2.0.0"
+safe-eth-py = ">=6.0.0b14,<7.0.0"
+scikit-learn = ">=1.3.1,<2.0.0"
+streamlit = ">=1.31.0,<2.0.0"
+subgrounds = ">=1.9.1,<2.0.0"
+tabulate = ">=0.9.0,<0.10.0"
+tqdm = ">=4.66.2,<5.0.0"
 typer = ">=0.9.0,<1.0.0"
-types-pytz = "^2024.1.0.20240203"
-types-requests = "^2.31.0.0"
-web3 = "^6.15.1"
+types-pytz = ">=2024.1.0.20240203,<2025.0.0.0"
+types-requests = ">=2.31.0.0,<3.0.0.0"
+web3 = ">=6.15.1,<7.0.0"
 
 [package.extras]
 google = ["google-api-python-client (==2.95.0)"]
 langchain = ["langchain (>=0.1.9,<0.2.0)", "langchain-openai (>=0.0.5,<0.0.6)"]
 openai = ["openai (>=1.0.0,<2.0.0)"]
-
-[package.source]
-type = "git"
-url = "https://github.com/gnosis/prediction-market-agent-tooling.git"
-reference = "evan/get_positions_value"
-resolved_reference = "08308c63b4116d4bc35429fcb93fbe5bf52f132e"
 
 [[package]]
 name = "preshed"
@@ -9860,4 +9856,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.0"
-content-hash = "bffe6eb19c69ece495f507c71c017a1ad65962e68432616355b7fdcc5a605f8b"
+content-hash = "51e397fc663026ba988c2a241087038a3bd2c13569eb9cc9c747bf2b5a79780a"

--- a/prediction_market_agent/agents/microchain_agent/market_functions.py
+++ b/prediction_market_agent/agents/microchain_agent/market_functions.py
@@ -307,6 +307,7 @@ class GetLiquidPositions(MarketFunction):
         positions = self.market_type.market_class.get_positions(
             user_id=self.user_address,
             liquid_only=True,
+            larger_than=1e-4,  # Ignore very small positions
         )
         return [str(position) for position in positions]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ poetry = "^1.7.1"
 poetry-plugin-export = "^1.6.0"
 functions-framework = "^3.5.0"
 cron-validator = "^1.0.8"
-prediction-market-agent-tooling = { git = "https://github.com/gnosis/prediction-market-agent-tooling.git", branch = "evan/get_positions_value", extras = ["langchain", "google"] }
+prediction-market-agent-tooling = { version = "^0.39.3", extras = ["langchain", "google"] }
 pydantic-settings = "^2.1.0"
 autoflake = "^2.2.1"
 isort = "^5.13.2"


### PR DESCRIPTION
Fixes the problem where, when you sell a position, due to small rounding errors, you are left with a tiny number of tokens. This shows up in subsequent `GetLiquidPositions` calls, which may be confusing for the agent!

<img width="606" alt="Screenshot 2024-06-26 at 16 10 46" src="https://github.com/gnosis/prediction-market-agent/assets/56087052/a791b19f-aed6-4a8e-822e-5be84091d845">

☝️ this no longer happens after this PR