### PR TITLE
Microchain `build_agent` should take openai api key argument

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/app.py
+++ b/prediction_market_agent/agents/microchain_agent/app.py
@@ -134,6 +134,7 @@ def maybe_initialize_agent(model: str, system_prompt: str) -> None:
                 if st.session_state.get("load_historical_prompt")
                 else None
             ),
+            openai_api_key=APIKeys().openai_api_key,
         )
         st.session_state.agent.reset()
         st.session_state.agent.build_initial_messages()

--- a/prediction_market_agent/agents/microchain_agent/deploy.py
+++ b/prediction_market_agent/agents/microchain_agent/deploy.py
@@ -15,6 +15,7 @@ from prediction_market_agent.db.long_term_memory_table_handler import (
     LongTermMemoryTableHandler,
 )
 from prediction_market_agent.db.prompt_table_handler import PromptTableHandler
+from prediction_market_agent.utils import APIKeys
 
 
 class DeployableMicrochainAgent(DeployableAgent):
@@ -44,6 +45,7 @@ class DeployableMicrochainAgent(DeployableAgent):
             allow_stop=True,
             long_term_memory=long_term_memory,
             prompt_handler=prompt_handler if self.load_historical_prompt else None,
+            openai_api_key=APIKeys().openai_api_key,
         )
         agent.run(self.n_iterations)
         long_term_memory.save_history(agent.history)

--- a/prediction_market_agent/agents/microchain_agent/microchain_agent.py
+++ b/prediction_market_agent/agents/microchain_agent/microchain_agent.py
@@ -2,6 +2,7 @@ import typer
 from microchain import LLM, Agent, Engine, Function, OpenAIChatGenerator
 from microchain.functions import Reasoning, Stop
 from prediction_market_agent_tooling.markets.markets import MarketType
+from pydantic import SecretStr
 
 from prediction_market_agent.agents.microchain_agent.agent_functions import (
     AGENT_FUNCTIONS,
@@ -62,6 +63,7 @@ def build_agent(
     market_type: MarketType,
     model: str,
     system_prompt: str,
+    openai_api_key: SecretStr,
     api_base: str = "https://api.openai.com/v1",
     long_term_memory: LongTermMemoryTableHandler | None = None,
     allow_stop: bool = True,
@@ -71,7 +73,7 @@ def build_agent(
     engine = Engine()
     generator = OpenAIChatGenerator(
         model=model,
-        api_key=APIKeys().openai_api_key.get_secret_value(),
+        api_key=openai_api_key.get_secret_value(),
         api_base=api_base,
         temperature=0.7,
     )
@@ -129,6 +131,7 @@ def main(
         long_term_memory=long_term_memory,
         allow_stop=False,  # Prevent the agent from stopping itself
         prompt_handler=prompt_handler,
+        openai_api_key=APIKeys().openai_api_key,
     )
     if seed_prompt:
         agent.bootstrap = [f'Reasoning("{seed_prompt}")']

--- a/scripts/deployed_general_agent_viewer.py
+++ b/scripts/deployed_general_agent_viewer.py
@@ -6,6 +6,8 @@ Tip: if you specify PYTHONPATH=., streamlit will watch for the changes in all fi
 
 
 # Imports using asyncio (in this case mech_client) cause issues with Streamlit
+from pydantic import SecretStr
+
 from prediction_market_agent.tools.streamlit_utils import (  # isort:skip
     display_chat_history,
     streamlit_asyncio_event_loop_hack,
@@ -129,6 +131,7 @@ agent = build_agent(
     market_type=MARKET_TYPE,
     model="foo",  # placeholder, not used
     system_prompt="foo",  # placeholder, not used
+    openai_api_key=SecretStr("foo"),  # placeholder, not used
     allow_stop=True,
     long_term_memory=long_term_memory,
     prompt_handler=None,


### PR DESCRIPTION
Currently the `Tool Usage` section of https://deployed-general-agent-viewer.ai.gnosisdev.com/ fails because the app doesn't have an openai api key in its env. It shouldn't need one, but it currently has to build a dummy agent (by calling `build_agent`).

By passing the api key in explicitly, instead of using `APIKeys()` internally, we can work around it by passing in a placeholder key