### PR TITLE
Fix 'iterations' metric in deployed agent viewer app

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/memory.py
+++ b/prediction_market_agent/agents/microchain_agent/memory.py
@@ -79,13 +79,21 @@ class ChatHistory(BaseModel):
     def num_messages(self) -> int:
         return len(self.chat_messages)
 
+    @property
+    def is_empty(self) -> bool:
+        return self.num_messages == 0
+
+    @property
+    def iterations(self) -> int:
+        # Number of messages:
+        #   -1 (for sys prompt)
+        #   divide by 2 (for user and assistant messages)
+        #   round down to nearest integer (in case the session ended with a failed function call)
+        return (self.num_messages - 1) // 2
+
 
 class DatedChatHistory(ChatHistory):
     chat_messages: Sequence[DatedChatMessage]
-
-    @property
-    def is_empty(self) -> bool:
-        return len(self.chat_messages) == 0
 
     @property
     def start_time(self) -> datetime:

--- a/scripts/deployed_general_agent_viewer.py
+++ b/scripts/deployed_general_agent_viewer.py
@@ -135,7 +135,7 @@ with st.container(border=True):
         if chat_history.is_empty
         else chat_history.start_time.strftime("%Y-%m-%d %H:%M:%S"),
     )
-    col2.metric("Number of iterations", len(chat_history.chat_messages))
+    col2.metric("Number of iterations", chat_history.iterations)
     col3.metric("Starting Balance", f"{starting_balance:.2f} {currency}")
     col4.metric(
         "Total Asset Value",


### PR DESCRIPTION
e.g. `general-agent-1` has run for 50 iterations (1 session), but currently its metric shows 101 iterations!!

Before:
<img width="637" alt="Screenshot 2024-07-17 at 17 16 25" src="https://github.com/user-attachments/assets/7bf373a2-cc38-4907-a3f1-0b3bd9a05fa4">

After:
<img width="702" alt="Screenshot 2024-07-17 at 17 33 57" src="https://github.com/user-attachments/assets/8ffd90f6-3397-42ea-a763-67a1f76aca42">
