### PR TITLE
Replace cluster_by_datetime with cluster_by_session on DatedChatHistory class

### DIFF
--- a/scripts/deployed_general_agent_viewer.py
+++ b/scripts/deployed_general_agent_viewer.py
@@ -120,7 +120,7 @@ with st.sidebar:
 
 long_term_memory = LongTermMemoryTableHandler(task_description=task_description)
 chat_history = DatedChatHistory.from_long_term_memory(long_term_memory=long_term_memory)
-sessions = chat_history.cluster_by_datetime(max_minutes_between_messages=30)
+sessions = chat_history.cluster_by_session()
 
 total_asset_value = get_total_asset_value(keys, MARKET_TYPE).amount
 roi = (total_asset_value - starting_balance) * 100 / starting_balance


### PR DESCRIPTION
A more reliable way to cluster chat messages, which is especially useful if doing testing (where you might want to run sessions manually back-to-back, not have to re-configure time-between-sessions arg.

<img width="386" alt="Screenshot 2024-07-18 at 12 38 12" src="https://github.com/user-attachments/assets/c3e58c5a-89d8-43c9-9a78-67fff13712bc">
