### PR TITLE
Adjust 'PROBABILITY_CLASS_OUTPUT' prompt for ThinkThoroughly agent

### DIFF
--- a/prediction_market_agent/agents/think_thoroughly_agent/prompts.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/prompts.py
@@ -138,6 +138,6 @@ Your response should be a JSON string containing the following keys:
 - "p_no": Probability that the sentence outcome will be `No`. Ranging from 0 (lowest probability) to 1 (maximum probability).
 - "confidence": Indicating the confidence in the estimated probabilities you provided ranging from 0 (lowest confidence) to 1 (maximum confidence). Confidence can be calculated based on the quality and quantity of data used for the estimation.
 
-Do not surround the output object with escape quotes, line breaks nor '''. 
+Return your answer in raw JSON format, with no special formatting such as newlines.
 Do not output any other text, only the JSON object. 
 Ensure p_yes + p_no equals 1."""


### PR DESCRIPTION
Tries to fix https://github.com/gnosis/prediction-market-agent/issues/357

Tried a few questions to reproduce the error, but was unable to 🤷. Giving this a go...