### PR TITLE
Change agent's prompt to prevent it from replying with mis-formatted function call

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/prompts.py
+++ b/prediction_market_agent/agents/microchain_agent/prompts.py
@@ -9,7 +9,7 @@ SYSTEM_PROMPT = f"""Act as an autonomous agent with a goal to learn, survive and
 
 {{engine_help}}
 
-Only output valid Python function calls, without code formatting characters, without any other text.
+Only output valid Python function calls, without code formatting characters, without any other text. i.e. it should run if passed to Python's `eval` function.
 Only output a single function call per message.
 """
 # This is the original system prompt of the microchain agent, users on Streamlit can select this,
@@ -29,7 +29,7 @@ You know everything needed and now just trade on the markets.
 
 {{engine_help}}
 
-Only output valid Python function calls, without code formatting characters, without any other text.
+Only output valid Python function calls, without code formatting characters, without any other text. i.e. it should run if passed to Python's `eval` function.
 Only output a single function call per message.
 Make 'Reasoning' calls frequently - at least every other call.
 """


### PR DESCRIPTION
Fixes https://github.com/gnosis/prediction-market-agent/issues/354
There may be many reasons for this, so we might need to re-open it if we see it again. For now, the only case I've been able to reproduce is where the agent calls a function without brackets (e.g. `GetMarkets` instead of `GetMarkets()`). This is parsed by `Agent.clean_reply` here https://github.com/galatolofederico/microchain/blob/main/microchain/engine/agent.py#L93 and becomes an empty string.

This change to the prompt fixes it.

From 10 tries before/after:

- before: 80% incorrect calls to GetMarkets, it does 3x retries always with the same error
- after: 70% correct calls to `GetMarkets()`/`GetBalance()`, always corrected the calls in the remaining 30% of cases (i.e. `GetMarkets` -> `GetMarkets()`

This could also be corrected in microchain itself - I've made an issue here and will look at that too https://github.com/galatolofederico/microchain/issues/14. But I don't think it has to be one or the other - we can have both fixes.