### PR TITLE
Fix json output parsing for the crew in ThinkThoroughlyWithItsOwnResearch.generate_prediction_for_one_outcome

### DIFF
--- a/prediction_market_agent/agents/think_thoroughly_agent/think_thoroughly_agent.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/think_thoroughly_agent.py
@@ -211,7 +211,9 @@ class ThinkThoroughlyBase(ABC):
         )
 
         report_crew = Crew(agents=[researcher], tasks=[create_scenarios_task])
-        scenarios = report_crew.kickoff(inputs={"scenario": question, "n_scenarios": 5})
+        scenarios: Scenarios = report_crew.kickoff(
+            inputs={"scenario": question, "n_scenarios": 5}
+        )
 
         # Add the original question if it wasn't included by the LLM.
         if question not in scenarios.scenarios:


### PR DESCRIPTION
Fixes https://github.com/gnosis/prediction-market-agent/issues/357

crewai has this nice feature for parsing the output of a `Task` to a pydantic object that we weren't using 😀