### PR TITLE
Save microchain agent history even if an exception is thrown

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/deploy.py
+++ b/prediction_market_agent/agents/microchain_agent/deploy.py
@@ -64,8 +64,6 @@ class DeployableMicrochainAgent(DeployableAgent):
 
         try:
             agent.run(self.n_iterations)
-        except Exception as e:
-            raise e
         finally:
             save_agent_history(
                 agent=agent,

--- a/prediction_market_agent/agents/microchain_agent/deploy.py
+++ b/prediction_market_agent/agents/microchain_agent/deploy.py
@@ -62,15 +62,18 @@ class DeployableMicrochainAgent(DeployableAgent):
         # Save formatted system prompt
         initial_formatted_system_prompt = agent.system_prompt
 
-        agent.run(self.n_iterations)
-
-        save_agent_history(
-            agent=agent,
-            long_term_memory=long_term_memory,
-            initial_system_prompt=initial_formatted_system_prompt,
-        )
-        if agent.system_prompt != initial_formatted_system_prompt:
-            prompt_handler.save_prompt(get_editable_prompt_from_agent(agent))
+        try:
+            agent.run(self.n_iterations)
+        except Exception as e:
+            raise e
+        finally:
+            save_agent_history(
+                agent=agent,
+                long_term_memory=long_term_memory,
+                initial_system_prompt=initial_formatted_system_prompt,
+            )
+            if agent.system_prompt != initial_formatted_system_prompt:
+                prompt_handler.save_prompt(get_editable_prompt_from_agent(agent))
 
 
 class DeployableMicrochainModifiableSystemPromptAgentAbstract(


### PR DESCRIPTION
See an example where an agent runs for some number of iterations, but throws an exception:
<img width="1058" alt="Screenshot 2024-08-23 at 09 53 28" src="https://github.com/user-attachments/assets/d54fd21a-65d5-4795-a5cb-d61e6a968468">

On https://deployed-general-agent-viewer.ai.gnosisdev.com/ the agent's chat history is empty for that session, as the agent doesn't save its history up to the point of the exception
<img width="313" alt="Screenshot 2024-08-23 at 10 15 53" src="https://github.com/user-attachments/assets/e36aace7-e676-4408-88b3-0b1667f06722">
