### PR TITLE
Do not register 'agent functions' for microchain trader agent

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/prompts.py
+++ b/prediction_market_agent/agents/microchain_agent/prompts.py
@@ -82,6 +82,7 @@ class FunctionsConfig(BaseModel):
     include_learning_functions: bool
     include_trading_functions: bool
     include_universal_functions: bool
+    include_agent_functions: bool
 
     @staticmethod
     def from_system_prompt_choice(
@@ -90,9 +91,11 @@ class FunctionsConfig(BaseModel):
         include_trading_functions = False
         include_learning_functions = False
         include_universal_functions = False
+        include_agent_functions = False
 
         if system_prompt_choice == SystemPromptChoice.JUST_BORN:
             include_learning_functions = True
+            include_agent_functions = True
             include_trading_functions = True
 
         elif system_prompt_choice == SystemPromptChoice.TRADING_AGENT:
@@ -100,12 +103,14 @@ class FunctionsConfig(BaseModel):
 
         elif system_prompt_choice == SystemPromptChoice.TASK_AGENT:
             include_universal_functions = True
+            include_agent_functions = True
             include_trading_functions = True
 
         return FunctionsConfig(
             include_trading_functions=include_trading_functions,
             include_learning_functions=include_learning_functions,
             include_universal_functions=include_universal_functions,
+            include_agent_functions=include_agent_functions,
         )
 
 

--- a/scripts/deployed_general_agent_viewer.py
+++ b/scripts/deployed_general_agent_viewer.py
@@ -171,6 +171,7 @@ agent = build_agent(
         include_trading_functions=True,  # placeholder, not used
         include_learning_functions=True,  # placeholder, not used
         include_universal_functions=True,  # placeholder, not used
+        include_agent_functions=True,  # placeholder, not used
     ),
 )
 tab1, tab2 = st.tabs(["Overall", "Per-Session"])


### PR DESCRIPTION
The trader agent has a fixed prompt - no need to give it the ability to introspect its system prompt, or update it