### PR TITLE
Set default bet size for various deployed agents to '1'

### DIFF
--- a/prediction_market_agent/agents/known_outcome_agent/deploy.py
+++ b/prediction_market_agent/agents/known_outcome_agent/deploy.py
@@ -1,4 +1,7 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
+from prediction_market_agent_tooling.deploy.betting_strategy import (
+    MaxAccuracyBettingStrategy,
+)
 from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import ProbabilisticAnswer
@@ -15,6 +18,7 @@ from prediction_market_agent.agents.utils import market_is_saturated
 class DeployableKnownOutcomeAgent(DeployableTraderAgent):
     model = "gpt-4-1106-preview"
     min_liquidity = 5
+    strategy = MaxAccuracyBettingStrategy(bet_amount=1)
 
     def load(self) -> None:
         self.markets_with_known_outcomes: dict[str, Result] = {}

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -1,5 +1,8 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
-from prediction_market_agent_tooling.deploy.betting_strategy import KellyBettingStrategy
+from prediction_market_agent_tooling.deploy.betting_strategy import (
+    KellyBettingStrategy,
+    MaxAccuracyBettingStrategy,
+)
 from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import ProbabilisticAnswer
@@ -18,6 +21,7 @@ from prediction_market_agent.utils import DEFAULT_OPENAI_MODEL
 class DeployableTraderAgentER(DeployableTraderAgent):
     agent: PredictionProphetAgent | OlasAgent
     bet_on_n_markets_per_run = 1
+    strategy = MaxAccuracyBettingStrategy(bet_amount=1)
 
     @property
     def model(self) -> str | None:

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -1,5 +1,6 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
 from prediction_market_agent_tooling.deploy.betting_strategy import (
+    BettingStrategy,
     KellyBettingStrategy,
     MaxAccuracyBettingStrategy,
 )
@@ -21,7 +22,7 @@ from prediction_market_agent.utils import DEFAULT_OPENAI_MODEL
 class DeployableTraderAgentER(DeployableTraderAgent):
     agent: PredictionProphetAgent | OlasAgent
     bet_on_n_markets_per_run = 1
-    strategy = MaxAccuracyBettingStrategy(bet_amount=1)
+    strategy: BettingStrategy = MaxAccuracyBettingStrategy(bet_amount=1)
 
     @property
     def model(self) -> str | None:

--- a/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
@@ -1,5 +1,6 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
 from prediction_market_agent_tooling.deploy.betting_strategy import (
+    BettingStrategy,
     KellyBettingStrategy,
     MaxAccuracyBettingStrategy,
 )
@@ -18,7 +19,7 @@ class DeployableThinkThoroughlyAgentBase(DeployableTraderAgent):
     agent_class: type[ThinkThoroughlyBase]
     model: str
     bet_on_n_markets_per_run = 1
-    strategy = MaxAccuracyBettingStrategy(bet_amount=1)
+    strategy: BettingStrategy = MaxAccuracyBettingStrategy(bet_amount=1)
 
     def load(self) -> None:
         self.agent = self.agent_class(

--- a/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
@@ -1,5 +1,8 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
-from prediction_market_agent_tooling.deploy.betting_strategy import KellyBettingStrategy
+from prediction_market_agent_tooling.deploy.betting_strategy import (
+    KellyBettingStrategy,
+    MaxAccuracyBettingStrategy,
+)
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import ProbabilisticAnswer
 from prediction_market_agent_tooling.markets.markets import MarketType
@@ -15,6 +18,7 @@ class DeployableThinkThoroughlyAgentBase(DeployableTraderAgent):
     agent_class: type[ThinkThoroughlyBase]
     model: str
     bet_on_n_markets_per_run = 1
+    strategy = MaxAccuracyBettingStrategy(bet_amount=1)
 
     def load(self) -> None:
         self.agent = self.agent_class(


### PR DESCRIPTION
The motivation is to address https://github.com/gnosis/prediction-market-agent/issues/430, except:
1. we don't actually re-implement the strategy that prophet agents used).
2. we also bump the bet size of think-thoroughly agents to be inline with other deployed agents

For context:

<img width="644" alt="Screenshot 2024-08-29 at 17 48 06" src="https://github.com/user-attachments/assets/d1e33970-dc8f-453f-b750-6f96506d4b50">