### PR TITLE
Ask goal manager to reason about follow-up goal selection more

### DIFF
--- a/prediction_market_agent/agents/goal_manager.py
+++ b/prediction_market_agent/agents/goal_manager.py
@@ -17,7 +17,6 @@ from prediction_market_agent.utils import DEFAULT_OPENAI_MODEL, APIKeys
 
 GENERATE_GOAL_PROMPT_TEMPLATE = """
 Generate a specific goal for an open-ended, autonomous agent that has a high-level description and a number of specific capabilities.
-If applicable, use the agent's previous evaluated goals when considering its new goal.
 
 The goal should satisfy the following:
 - have a narrow focus
@@ -28,13 +27,17 @@ The goal should satisfy the following:
 - balance the need for exploration and exploitation
 - not be contingent on external factors that are out of the agent's control
 
+If applicable, use the agent's previous evaluated goals when considering its new goal, and state how this goal follows from the previous ones in the 'reasoning' field.
+
 [HIGH LEVEL DESCRIPTION]
 {high_level_description}
 
 [AGENT CAPABILITIES]
 {agent_capabilities}
 
+[PREVIOUS EVALUATED GOALS]
 {previous_evaluated_goals}
+
 {format_instructions}
 """
 
@@ -299,6 +302,8 @@ class GoalManager:
 
     @staticmethod
     def evaluated_goals_to_str(evaluated_goals: list[EvaluatedGoal]) -> str:
+        if not evaluated_goals:
+            return "-- None --"
         goals_str = ""
         for i, goal in enumerate(evaluated_goals):
             goals_str += f"## Goal {i+1}:\n{goal}\n"

--- a/tests/agents/test_goal_manager.py
+++ b/tests/agents/test_goal_manager.py
@@ -64,7 +64,12 @@ def test_have_reached_retry_limit() -> None:
     )
 
 
-def test_evaluated_goals_to_str() -> None:
+def test_evaluated_goals_to_str_0() -> None:
+    goals_str = GoalManager.evaluated_goals_to_str([])
+    assert goals_str == "-- None --"
+
+
+def test_evaluated_goals_to_str_1() -> None:
     gs = [
         EvaluatedGoal(
             goal="foo0",
@@ -126,14 +131,13 @@ def test_generate_goal() -> None:
         reasoning="The Tour de France is cancelled this year.",
         output=None,
     )
-    goal2 = goal_manager.generate_goal(latest_evaluated_goals=[evaluated_goal])
-
+    goal1 = goal_manager.generate_goal(latest_evaluated_goals=[evaluated_goal])
     # Generates a goal related to the Tour de France
     assert "Tour de France" in goal0.goal
 
     # Does not generate a goal related to the Tour de France, based on the
     # reasoning of the previous evaluated goal
-    assert "Tour de France" not in goal2.goal
+    assert "Tour de France" not in goal1.goal
 
 
 def test_get_chat_history_after_goal_prompt() -> None:


### PR DESCRIPTION
Current deployment of `trader-agent-0-with-goal-manager` is producing goals one after another that are quite similar (i.e. not too much exploration). Encourage agent to reason about why one goal should follow the previous one.