### PR TITLE
Use FunctionsConfig.include_agent_functions in build_agent_functions logic

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/microchain_agent.py
+++ b/prediction_market_agent/agents/microchain_agent/microchain_agent.py
@@ -113,7 +113,8 @@ def build_agent_functions(
     if allow_stop:
         functions.append(Stop())
 
-    functions.extend([f(agent=agent) for f in AGENT_FUNCTIONS])
+    if functions_config.include_agent_functions:
+        functions.extend([f(agent=agent) for f in AGENT_FUNCTIONS])
 
     if functions_config.include_universal_functions:
         functions.extend([f() for f in API_FUNCTIONS])


### PR DESCRIPTION
Noticed deployed trader agents still had the ability to get and update their system prompt. Simple fix

<img width="1374" alt="Screenshot 2024-09-06 at 15 41 54" src="https://github.com/user-attachments/assets/b74bc0d0-5307-4078-9d62-cbfea17840b5">
