### PR TITLE
Update DeployableTraderAgent betting stategies for max profit, based on historical simulations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -665,17 +665,17 @@ numpy = {version = ">=1.19.0", markers = "python_version >= \"3.9\""}
 
 [[package]]
 name = "boto3"
-version = "1.35.32"
+version = "1.35.33"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.35.32-py3-none-any.whl", hash = "sha256:786a243f4b4827c6ae149442bf544c2ae449570cf23616a5d386f7a2633e0e08"},
-    {file = "boto3-1.35.32.tar.gz", hash = "sha256:a7652962897340d34bc930ffc9311dcc441da975dd1b904d0172b06adbea3601"},
+    {file = "boto3-1.35.33-py3-none-any.whl", hash = "sha256:4064e95d4035d4d3dd4eb59eaa5908d14d194b512d1dc1d271647b0c661fbdbb"},
+    {file = "boto3-1.35.33.tar.gz", hash = "sha256:d206e8295e856ded7c8fab086784dc17863ed9d735458145c2ef5b25604aef69"},
 ]
 
 [package.dependencies]
-botocore = ">=1.35.32,<1.36.0"
+botocore = ">=1.35.33,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -684,13 +684,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.35.32"
+version = "1.35.33"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.32-py3-none-any.whl", hash = "sha256:2c0c2b62dd156daf904525f3f523ae22bf34ac109d727acf0bbfbca291440fc3"},
-    {file = "botocore-1.35.32.tar.gz", hash = "sha256:5ecbcd2f112e991b1f95c88ebb0f8df1a7c4ad9681aff80ec77e67cc4836eaa9"},
+    {file = "botocore-1.35.33-py3-none-any.whl", hash = "sha256:b7b1ed59a224616912c7546fa19ffd542c745818179ee0640a8a00b155bcd9cd"},
+    {file = "botocore-1.35.33.tar.gz", hash = "sha256:b149940c59aa318e020191c9e5644361b2371e77d0346a3819728b49d3fa2e4e"},
 ]
 
 [package.dependencies]
@@ -699,7 +699,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
-crt = ["awscrt (==0.21.5)"]
+crt = ["awscrt (==0.22.0)"]
 
 [[package]]
 name = "bs4"
@@ -3508,6 +3508,27 @@ lint = ["black (>=22)", "flake8 (==6.0.0)", "flake8-bugbear (==23.3.23)", "isort
 test = ["eth-utils (>=1.0.1,<3)", "hypothesis (>=3.44.24,<=6.31.6)", "pytest (>=7.0.0)", "pytest-xdist (>=2.4.0)"]
 
 [[package]]
+name = "hishel"
+version = "0.0.31"
+description = "Persistent cache implementation for httpx and httpcore"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "hishel-0.0.31-py3-none-any.whl", hash = "sha256:8c0b4b3e6861d3eb643dccbedbe84e559d8422bdc58ebfea8ea8a5419ca18f52"},
+    {file = "hishel-0.0.31.tar.gz", hash = "sha256:0577291a0159a466152096e2b8ac33c476707eb6a44e5dca6de5a855d7fbd38b"},
+]
+
+[package.dependencies]
+httpx = ">=0.22.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+redis = ["redis (==5.0.1)"]
+s3 = ["boto3 (>=1.15.0,<=1.15.3)", "boto3 (>=1.15.3)"]
+sqlite = ["anysqlite (>=0.0.5)"]
+yaml = ["pyyaml (==6.0.1)"]
+
+[[package]]
 name = "hpack"
 version = "4.0.0"
 description = "Pure-Python HPACK header compression"
@@ -4438,13 +4459,13 @@ openai = ["openai (>=0.27.8)"]
 
 [[package]]
 name = "langsmith"
-version = "0.1.130"
+version = "0.1.131"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.130-py3-none-any.whl", hash = "sha256:acf27d77e699d84b03045f3f226e78be1dffb3e756aa1a085f9993a45380e8b2"},
-    {file = "langsmith-0.1.130.tar.gz", hash = "sha256:3e43f87655a86395133e3a745d5968667d4d05dc9a24c617f89224c8cbf54dce"},
+    {file = "langsmith-0.1.131-py3-none-any.whl", hash = "sha256:80c106b1c42307195cc0bb3a596472c41ef91b79d15bcee9938307800336c563"},
+    {file = "langsmith-0.1.131.tar.gz", hash = "sha256:626101a3bf3ca481e5110d5155ace8aa066e4e9cc2fa7d96c8290ade0fbff797"},
 ]
 
 [package.dependencies]
@@ -5933,18 +5954,18 @@ sympy = "*"
 
 [[package]]
 name = "open-aea"
-version = "1.57.0"
+version = "1.58.0"
 description = "Open Autonomous Economic Agent framework (without vendor lock-in)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "open_aea-1.57.0-py3-none-any.whl", hash = "sha256:19714577414fa7ce7c9a43e4dd9d7849189b77b158a3d60e75cb43a7ea0eecd5"},
-    {file = "open_aea-1.57.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:a56d0b6dfa5bcdcf24d0edd167bf0e90c205bb6f20b59bcee0975a8dbd1811fe"},
-    {file = "open_aea-1.57.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:a03df0c0e8354a8a0d940969252dbdf633f9b5698ce499e1cd30f694f7635151"},
-    {file = "open_aea-1.57.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1fb3c78c7877bcd41d33b3bd5ee51f2cfe62efa2a07f193838133c771fff5237"},
-    {file = "open_aea-1.57.0-py3-none-win32.whl", hash = "sha256:a068d8710d3e235499ae866d167825bca1b56314f255b05591b2e362c1f9b3a6"},
-    {file = "open_aea-1.57.0-py3-none-win_amd64.whl", hash = "sha256:eb2ef61a7e7d74f4b99fc27fdbad7350320c18528f85678fe1a6503736ef2de5"},
-    {file = "open_aea-1.57.0.tar.gz", hash = "sha256:7cef260f56a4214752ea6242d43cf20a7488815f7e2de53ff2836b57a650a385"},
+    {file = "open_aea-1.58.0-py3-none-any.whl", hash = "sha256:ebe4b908279567a712cfe324480af8530d7e8f85d167af112ab0e176f8b6e911"},
+    {file = "open_aea-1.58.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:20fb1979d5e4d9b7e5d87b28141980509ce8871f6d521eb2b8b418fd799dd264"},
+    {file = "open_aea-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:f9750158cf3a3f460ba12fb02b66c0998c9de69d9cccb21307c3bfd03feb1d97"},
+    {file = "open_aea-1.58.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:b1ae7f75503dc72f8c11a7e154362df808527abacd5c043a1fba6db49d1d144c"},
+    {file = "open_aea-1.58.0-py3-none-win32.whl", hash = "sha256:28e540ae7dc5e09d704fb7c20e1db42c1ce240e5effa77caa1ba5427c539a28a"},
+    {file = "open_aea-1.58.0-py3-none-win_amd64.whl", hash = "sha256:9a7ea0b11c7b2625abdf93a9e1a17c74df0cd52e12edcfad9a95d731bce9cc56"},
+    {file = "open_aea-1.58.0.tar.gz", hash = "sha256:46c2085a5ffba482c7421af517d770626a65ee0521cba9f08ce53c99186d4e3c"},
 ]
 
 [package.dependencies]
@@ -5972,13 +5993,13 @@ test-tools = ["click (>=8.1.0,<9)", "coverage (>=6.4.4,<8.0.0)", "jsonschema (>=
 
 [[package]]
 name = "open-aea-cli-ipfs"
-version = "1.57.0"
+version = "1.58.0"
 description = "CLI extension for open AEA framework wrapping IPFS functionality."
 optional = false
 python-versions = "*"
 files = [
-    {file = "open_aea_cli_ipfs-1.57.0-py3-none-any.whl", hash = "sha256:6cbefd42a682f1f0c116e527f728998f61a9bc930995acdd754b5335e54ad97d"},
-    {file = "open_aea_cli_ipfs-1.57.0.tar.gz", hash = "sha256:8254a1ecef4e7e3dbc9ba990243413963a0d5055b336c1ce6f2e0ae4ddaa25ce"},
+    {file = "open_aea_cli_ipfs-1.58.0-py3-none-any.whl", hash = "sha256:f54b389d98ff17962b631b79014fcc2c8eaf0171e83c8e0e1d0ae1c31f8361fe"},
+    {file = "open_aea_cli_ipfs-1.58.0.tar.gz", hash = "sha256:b34f37b673dfae84afff3d5c06ff7faf4c2b8477f23ed548b29b2b8f0e96da8d"},
 ]
 
 [package.dependencies]
@@ -5988,13 +6009,13 @@ pytest = ">=7.0.0,<7.3.0"
 
 [[package]]
 name = "open-aea-ledger-cosmos"
-version = "1.57.0"
+version = "1.58.0"
 description = "Python package wrapping the public and private key cryptography and ledger api of Cosmos."
 optional = false
 python-versions = "*"
 files = [
-    {file = "open_aea_ledger_cosmos-1.57.0-py3-none-any.whl", hash = "sha256:dfedc58ae4cebd938b51834f3eca5e2c8ffce95661a84212c3c4b6341e8952d4"},
-    {file = "open_aea_ledger_cosmos-1.57.0.tar.gz", hash = "sha256:35ae99e188a256bfcb06d510d161643922d6ed1e639eed92b3b5f7ee3576d5bf"},
+    {file = "open_aea_ledger_cosmos-1.58.0-py3-none-any.whl", hash = "sha256:2f1d2cd46a2f9b9cfa50c0e5db1b607c0c622bb6b9cabc32d42fea984c56a27e"},
+    {file = "open_aea_ledger_cosmos-1.58.0.tar.gz", hash = "sha256:49f6a3d0a5d9e37abe7c787f1c8e4dae55f0085e47ed98065e2ad99dfb9b490e"},
 ]
 
 [package.dependencies]
@@ -6006,13 +6027,13 @@ pycryptodome = ">=3.10.1,<4.0.0"
 
 [[package]]
 name = "open-aea-ledger-ethereum"
-version = "1.57.0"
+version = "1.58.0"
 description = "Python package wrapping the public and private key cryptography and ledger api of Ethereum."
 optional = false
 python-versions = "*"
 files = [
-    {file = "open_aea_ledger_ethereum-1.57.0-py3-none-any.whl", hash = "sha256:8ad775344baa77fc6b8e5a92edfa6d7e32f3361a885113379733e7ce4e4d6405"},
-    {file = "open_aea_ledger_ethereum-1.57.0.tar.gz", hash = "sha256:7c16858ad751db3906ec72046c821ad5b057c5e47edbc951da99c52714fb8c5e"},
+    {file = "open_aea_ledger_ethereum-1.58.0-py3-none-any.whl", hash = "sha256:06421f95a843814bc74d7c453530b4d71a8462ad0c6404d2039c525164e6da7b"},
+    {file = "open_aea_ledger_ethereum-1.58.0.tar.gz", hash = "sha256:2f5bbf330e573b5a455f2b109fc5884d9aa749ec7a20a1c7bd796bd7bc1ac414"},
 ]
 
 [package.dependencies]
@@ -6837,13 +6858,13 @@ tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "p
 
 [[package]]
 name = "posthog"
-version = "3.6.6"
+version = "3.7.0"
 description = "Integrate PostHog into any python application."
 optional = false
 python-versions = "*"
 files = [
-    {file = "posthog-3.6.6-py2.py3-none-any.whl", hash = "sha256:38834fd7f0732582a20d4eb4674c8d5c088e464d14d1b3f8c176e389aecaa4ef"},
-    {file = "posthog-3.6.6.tar.gz", hash = "sha256:1e04783293117109189ad7048f3eedbe21caff0e39bee5e2d47a93dd790fefac"},
+    {file = "posthog-3.7.0-py2.py3-none-any.whl", hash = "sha256:3555161c3a9557b5666f96d8e1f17f410ea0f07db56e399e336a1656d4e5c722"},
+    {file = "posthog-3.7.0.tar.gz", hash = "sha256:b095d4354ba23f8b346ab5daed8ecfc5108772f922006982dfe8b2d29ebc6e0e"},
 ]
 
 [package.dependencies]
@@ -6860,13 +6881,13 @@ test = ["coverage", "django", "flake8", "freezegun (==0.3.15)", "mock (>=2.0.0)"
 
 [[package]]
 name = "prediction-market-agent-tooling"
-version = "0.49.1"
+version = "0.49.2"
 description = "Tools to benchmark, deploy and monitor prediction market agents."
 optional = false
 python-versions = "<3.12,>=3.10"
 files = [
-    {file = "prediction_market_agent_tooling-0.49.1-py3-none-any.whl", hash = "sha256:50c850a4c5a6d81f8e3079676348170449e770506218ddbd5dcc4d3d17b9480e"},
-    {file = "prediction_market_agent_tooling-0.49.1.tar.gz", hash = "sha256:2af07a05cc5439afa4d3e7faa21e0d61fb14e0adb5f773aedb77e8206d779ab4"},
+    {file = "prediction_market_agent_tooling-0.49.2-py3-none-any.whl", hash = "sha256:cae0c7a96028f53470f88cf3a2cef264894c5c5244ed15d51dcd584a8d074786"},
+    {file = "prediction_market_agent_tooling-0.49.2.tar.gz", hash = "sha256:2815b57ad12e89e8a45a8921306f50de9b6df2bf7252a22e1b63883e1233b27b"},
 ]
 
 [package.dependencies]
@@ -6880,6 +6901,7 @@ google-api-python-client = {version = "2.95.0", optional = true, markers = "extr
 google-cloud-functions = ">=1.16.0,<2.0.0"
 google-cloud-resource-manager = ">=1.12.0,<2.0.0"
 google-cloud-secret-manager = ">=2.18.2,<3.0.0"
+hishel = ">=0.0.31,<0.0.32"
 isort = ">=5.13.2,<6.0.0"
 langchain = {version = ">=0.2.6,<0.3.0", optional = true, markers = "extra == \"langchain\""}
 langchain-community = ">=0.0.19"

--- a/prediction_market_agent/agents/known_outcome_agent/deploy.py
+++ b/prediction_market_agent/agents/known_outcome_agent/deploy.py
@@ -1,7 +1,7 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
 from prediction_market_agent_tooling.deploy.betting_strategy import (
     BettingStrategy,
-    MaxAccuracyBettingStrategy,
+    KellyBettingStrategy,
 )
 from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
@@ -21,7 +21,7 @@ class DeployableKnownOutcomeAgent(DeployableTraderAgent):
     min_liquidity = 5
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return MaxAccuracyBettingStrategy(bet_amount=1)
+        return KellyBettingStrategy(max_bet_amount=2, max_price_impact=0.6)
 
     def load(self) -> None:
         self.markets_with_known_outcomes: dict[str, Result] = {}

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -42,7 +42,7 @@ class DeployablePredictionProphetGPT4oAgent(DeployableTraderAgentER):
     agent: PredictionProphetAgent
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return KellyBettingStrategy(max_bet_amount=25, max_price_impact=0.5)
+        return KellyBettingStrategy(max_bet_amount=5, max_price_impact=0.7)
 
     def load(self) -> None:
         super().load()

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -1,7 +1,7 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
 from prediction_market_agent_tooling.deploy.betting_strategy import (
     BettingStrategy,
-    MaxAccuracyBettingStrategy,
+    KellyBettingStrategy,
 )
 from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
@@ -22,9 +22,6 @@ class DeployableTraderAgentER(DeployableTraderAgent):
     agent: PredictionProphetAgent | OlasAgent
     bet_on_n_markets_per_run = 1
 
-    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return MaxAccuracyBettingStrategy(bet_amount=1)
-
     @property
     def model(self) -> str | None:
         return self.agent.model
@@ -44,6 +41,9 @@ class DeployablePredictionProphetGPT4oAgent(DeployableTraderAgentER):
     bet_on_n_markets_per_run = 20
     agent: PredictionProphetAgent
 
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=25, max_price_impact=0.5)
+
     def load(self) -> None:
         super().load()
         self.agent = PredictionProphetAgent(
@@ -56,6 +56,9 @@ class DeployablePredictionProphetGPT4oAgent(DeployableTraderAgentER):
 
 class DeployablePredictionProphetGPT4TurboPreviewAgent(DeployableTraderAgentER):
     agent: PredictionProphetAgent
+
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=5, max_price_impact=0.5)
 
     def load(self) -> None:
         super().load()
@@ -70,6 +73,9 @@ class DeployablePredictionProphetGPT4TurboPreviewAgent(DeployableTraderAgentER):
 class DeployablePredictionProphetGPT4TurboFinalAgent(DeployableTraderAgentER):
     agent: PredictionProphetAgent
 
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=5, max_price_impact=None)
+
     def load(self) -> None:
         super().load()
         self.agent = PredictionProphetAgent(
@@ -83,6 +89,9 @@ class DeployablePredictionProphetGPT4TurboFinalAgent(DeployableTraderAgentER):
 class DeployableOlasEmbeddingOAAgent(DeployableTraderAgentER):
     agent: OlasAgent
 
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=25, max_price_impact=0.5)
+
     def load(self) -> None:
         super().load()
         self.agent = OlasAgent(
@@ -92,6 +101,9 @@ class DeployableOlasEmbeddingOAAgent(DeployableTraderAgentER):
 
 class DeployablePredictionProphetGPTo1PreviewAgent(DeployableTraderAgentER):
     agent: PredictionProphetAgent
+
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=25, max_price_impact=0.7)
 
     def load(self) -> None:
         super().load()
@@ -108,6 +120,9 @@ class DeployablePredictionProphetGPTo1PreviewAgent(DeployableTraderAgentER):
 
 class DeployablePredictionProphetGPTo1MiniAgent(DeployableTraderAgentER):
     agent: PredictionProphetAgent
+
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=5, max_price_impact=None)
 
     def load(self) -> None:
         super().load()

--- a/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
@@ -1,7 +1,7 @@
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
 from prediction_market_agent_tooling.deploy.betting_strategy import (
     BettingStrategy,
-    MaxAccuracyBettingStrategy,
+    KellyBettingStrategy,
 )
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import ProbabilisticAnswer
@@ -18,9 +18,6 @@ class DeployableThinkThoroughlyAgentBase(DeployableTraderAgent):
     agent_class: type[ThinkThoroughlyBase]
     model: str
     bet_on_n_markets_per_run = 1
-
-    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return MaxAccuracyBettingStrategy(bet_amount=1)
 
     def load(self) -> None:
         self.agent = self.agent_class(
@@ -41,10 +38,16 @@ class DeployableThinkThoroughlyAgent(DeployableThinkThoroughlyAgentBase):
     agent_class = ThinkThoroughlyWithItsOwnResearch
     model: str = "gpt-4-turbo-2024-04-09"
 
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=5, max_price_impact=None)
+
 
 class DeployableThinkThoroughlyProphetResearchAgent(DeployableThinkThoroughlyAgentBase):
     agent_class = ThinkThoroughlyWithPredictionProphetResearch
     model: str = "gpt-4-turbo-2024-04-09"
+
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return KellyBettingStrategy(max_bet_amount=5, max_price_impact=0.4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See simulation results in comment. For now, we take the highest simulated profit strategy for each agent, except for:

- DeployablePredictionProphetGPT4oAgent uses the 5th highest profit strategy (19% less profit for <50% less bet amount), because it has `bet_on_n_markets_per_run = 20` so its profitability is constrained more by how many bets it can make in parallel
- DeployableThinkThoroughlyProphetResearchAgent uses second highest profit strategy because it is verrry close to the highest profit strategy but has a significantly lower bet amount

If we change agents to have a larger `bet_on_n_markets_per_run`, we should also consider using the betting strategy with max ROI/capital efficiency instead.