### PR TITLE
Make goal manager create more varied goals

### DIFF
--- a/prediction_market_agent/agents/goal_manager.py
+++ b/prediction_market_agent/agents/goal_manager.py
@@ -63,6 +63,9 @@ class Goal(BaseModel):
         description="The criteria that will be used to evaluate whether the goal has been completed",
     )
 
+    class Config:
+        frozen = True  # Makes `Goal` immutable and hashable
+
     def to_prompt(self) -> str:
         return (
             f"# Goal:\n"

--- a/prediction_market_agent/agents/goal_manager.py
+++ b/prediction_market_agent/agents/goal_manager.py
@@ -331,10 +331,11 @@ class GoalManager:
         The input list is assumed to be sorted in descending order of datetime.
         """
         unique_evaluated_goals: list[EvaluatedGoal] = []
-        unique_goals: list[Goal] = []
+        unique_goals: set[Goal] = set()
         for goal in evaluated_goals:
-            if goal.to_goal() not in unique_goals:
-                unique_goals.append(goal.to_goal())
+            goal_obj = goal.to_goal()
+            if goal_obj not in unique_goals:
+                unique_goals.add(goal_obj)
                 unique_evaluated_goals.append(goal)
             if len(unique_evaluated_goals) == self.goal_history_limit:
                 break

--- a/prediction_market_agent/agents/microchain_agent/deploy.py
+++ b/prediction_market_agent/agents/microchain_agent/deploy.py
@@ -182,5 +182,6 @@ class DeployableMicrochainWithGoalManagerAgent0(DeployableMicrochainAgent):
             agent_id=self.task_description,
             high_level_description="You are a trader agent in prediction markets, aiming to maximise your long-term profit.",
             agent_capabilities=f"You have the following capabilities:\n{get_functions_summary_list(agent.engine)}",
-            retry_limit=3,
+            retry_limit=1,
+            goal_history_limit=10,
         )

--- a/tests/agents/test_goal_manager.py
+++ b/tests/agents/test_goal_manager.py
@@ -286,3 +286,33 @@ def test_evaluate_goal_progress_2() -> None:
     )
     assert goal_evaluation.is_complete is False
     assert goal_evaluation.output is None
+
+
+def test_get_unique_evaluated_goals() -> None:
+    goal_manager = GoalManager(
+        agent_id="",  # Not relevant to test
+        high_level_description="",  # Not relevant to test
+        agent_capabilities="",  # Not relevant to test
+        model=DEFAULT_OPENAI_MODEL,
+        sqlalchemy_db_url=SQLITE_DB_URL,
+        retry_limit=4,
+        goal_history_limit=3,
+    )
+    g0 = EvaluatedGoal(
+        goal="foo0",
+        motivation="bar0",
+        completion_criteria="baz0",
+        is_complete=False,
+        reasoning="qux0",
+        output=None,
+    )
+    g1 = g0.model_copy()
+
+    g2 = g0.model_copy()
+    g2.goal = "foo2"
+    g3 = g2.model_copy()
+
+    g4 = g0.model_copy()
+    g4.goal = "foo4"
+
+    assert goal_manager.get_unique_evaluated_goals([g0, g1, g2, g3, g4]) == [g0, g2, g4]

--- a/tests/agents/test_goal_manager.py
+++ b/tests/agents/test_goal_manager.py
@@ -20,16 +20,18 @@ def test_have_reached_retry_limit() -> None:
         sqlalchemy_db_url=SQLITE_DB_URL,
     )
 
-    g0 = EvaluatedGoal(
-        goal="goal0",
-        motivation="motivation",
-        completion_criteria="completion_criteria",
-        is_complete=False,
-        reasoning="reasoning",
-        output=None,
-    )
-    g1 = g0.model_copy()
-    g1.goal = "goal1"
+    def get_goal(goal: str) -> EvaluatedGoal:
+        return EvaluatedGoal(
+            goal=goal,
+            motivation="motivation",
+            completion_criteria="completion_criteria",
+            is_complete=False,
+            reasoning="reasoning",
+            output=None,
+        )
+
+    g0 = get_goal("goal0")
+    g1 = get_goal("goal1")
 
     assert goal_manager.have_reached_retry_limit(latest_evaluated_goals=[]) is True
 
@@ -298,21 +300,23 @@ def test_get_unique_evaluated_goals() -> None:
         retry_limit=4,
         goal_history_limit=3,
     )
-    g0 = EvaluatedGoal(
-        goal="foo0",
-        motivation="bar0",
-        completion_criteria="baz0",
-        is_complete=False,
-        reasoning="qux0",
-        output=None,
-    )
-    g1 = g0.model_copy()
 
-    g2 = g0.model_copy()
-    g2.goal = "foo2"
-    g3 = g2.model_copy()
+    def get_goal(goal: str) -> EvaluatedGoal:
+        return EvaluatedGoal(
+            goal=goal,
+            motivation="bar",
+            completion_criteria="baz",
+            is_complete=False,
+            reasoning="qux",
+            output=None,
+        )
 
-    g4 = g0.model_copy()
-    g4.goal = "foo4"
+    g0 = get_goal("foo0")
+    g1 = get_goal("foo0")
+
+    g2 = get_goal("foo2")
+    g3 = get_goal("foo2")
+
+    g4 = get_goal("foo4")
 
     assert goal_manager.get_unique_evaluated_goals([g0, g1, g2, g3, g4]) == [g0, g2, g4]


### PR DESCRIPTION
Currently there is not much variety in the goals generated by the goal manager.

This is because, when generating a new goal:
- goal manager has `self.retry_limit = N`
- goal is evaluated as having failed N times
- the goal manager only pulls in the past N goals, and they are all the same (failed) goal!
- so it has no visibility of earlier goals
- so generates a new goal that is very similar to earlier ones

The fixes are the following:
- Add new `goal_history_limit` property to `GoalManager`
- Pull in more goals when generating a new goal
- Only pull in unique past goals so the goal history is not filled with repeated failed goals