### PR TITLE
Only 10 iterations for Llama agent

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/deploy.py
+++ b/prediction_market_agent/agents/microchain_agent/deploy.py
@@ -164,7 +164,7 @@ class DeployableMicrochainModifiableSystemPromptAgent3(
     task_description = AgentIdentifier.MICROCHAIN_AGENT_OMEN_LEARNING_3
     model = SupportedModel.llama_31_instruct
     # Force less iterations, because Replicate's API allows at max 4096 input tokens.
-    n_iterations = 20
+    n_iterations = 10
     description = "Microchain agent with 'just born' system prompt, and ability to adjust its own system prompt, version 3. Uses Llama 3.1 model."
 
 


### PR DESCRIPTION
We are still getting `essage: "{"detail":"E1002 PromptTooLong: Prompt length exceeds maximum input length"}"`, these general agents probably need a more clever, general fix.