### PR TITLE
Cheaper think thoroughly prophet agent

### DIFF
--- a/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
@@ -18,13 +18,10 @@ from prediction_market_agent.utils import APIKeys
 
 class DeployableThinkThoroughlyAgentBase(DeployableTraderAgent):
     agent_class: type[ThinkThoroughlyBase]
-    model: str
     bet_on_n_markets_per_run = 1
 
     def load(self) -> None:
-        self.agent = self.agent_class(
-            model=self.model, enable_langfuse=self.enable_langfuse
-        )
+        self.agent = self.agent_class(enable_langfuse=self.enable_langfuse)
 
     def answer_binary_market(self, market: AgentMarket) -> ProbabilisticAnswer | None:
         return self.agent.answer_binary_market(
@@ -38,7 +35,6 @@ class DeployableThinkThoroughlyAgentBase(DeployableTraderAgent):
 
 class DeployableThinkThoroughlyAgent(DeployableThinkThoroughlyAgentBase):
     agent_class = ThinkThoroughlyWithItsOwnResearch
-    model: str = "gpt-4-turbo-2024-04-09"
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
         return KellyBettingStrategy(
@@ -51,7 +47,6 @@ class DeployableThinkThoroughlyAgent(DeployableThinkThoroughlyAgentBase):
 
 class DeployableThinkThoroughlyProphetResearchAgent(DeployableThinkThoroughlyAgentBase):
     agent_class = ThinkThoroughlyWithPredictionProphetResearch
-    model: str = "gpt-4-turbo-2024-04-09"
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
         return KellyBettingStrategy(

--- a/prediction_market_agent/agents/think_thoroughly_agent/think_thoroughly_agent.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/think_thoroughly_agent.py
@@ -105,9 +105,10 @@ class TavilySearchResultsThatWillThrow(TavilySearchResults):
 
 class ThinkThoroughlyBase(ABC):
     identifier: str
+    model: str
+    model_for_generate_prediction_for_one_outcome: str
 
-    def __init__(self, model: str, enable_langfuse: bool, memory: bool = True) -> None:
-        self.model = model
+    def __init__(self, enable_langfuse: bool, memory: bool = True) -> None:
         self.enable_langfuse = enable_langfuse
         self.subgraph_handler = OmenSubgraphHandler()
         self.pinecone_handler = PineconeHandler()
@@ -339,7 +340,7 @@ class ThinkThoroughlyBase(ABC):
                     (
                         self.enable_langfuse,
                         unique_id,
-                        self.model,
+                        self.model_for_generate_prediction_for_one_outcome,
                         scenario,
                         question,
                         scenarios_with_probs,
@@ -374,6 +375,8 @@ class ThinkThoroughlyBase(ABC):
 
 class ThinkThoroughlyWithItsOwnResearch(ThinkThoroughlyBase):
     identifier = "think-thoroughly-agent"
+    model = "gpt-4-turbo-2024-04-09"
+    model_for_generate_prediction_for_one_outcome = "gpt-4-turbo-2024-04-09"
 
     @staticmethod
     def generate_prediction_for_one_outcome(
@@ -439,6 +442,8 @@ class ThinkThoroughlyWithItsOwnResearch(ThinkThoroughlyBase):
 
 class ThinkThoroughlyWithPredictionProphetResearch(ThinkThoroughlyBase):
     identifier = "think-thoroughly-prophet-research-agent"
+    model = "gpt-4-turbo-2024-04-09"
+    model_for_generate_prediction_for_one_outcome = "gpt-4o-2024-08-06"
 
     @staticmethod
     def generate_prediction_for_one_outcome(


### PR DESCRIPTION
I think we can safely make think thoroughly prophet cheaper, by using gpt 4o on its prophet-research part.

Looking at Dune, gpt-4o prophet agent is among the best:

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/02ed6cc4-654f-4042-b9f2-2d851b76cf8e)

So if we switch to 4o only in the prophet-research part, it should still be good (if not better).