### PR TITLE
Show errored function in reasoning

### DIFF
--- a/prediction_market_agent/agents/microchain_agent/prompts.py
+++ b/prediction_market_agent/agents/microchain_agent/prompts.py
@@ -40,6 +40,7 @@ REQUIRED_PROMPT_ENDING_FOR_MICROCHAIN = f"""
 Only output valid Python function calls, without code formatting characters, without any other text.
 Only output a single function call per message.
 Make 'Reasoning' calls frequently - at least every other call.
+If some function errors out, include the exact function and arguments you tried to call in your follow-up reasoning call.
 """
 
 JUST_BORN_SYSTEM_PROMPT_CONFIG = SystemPromptConfig(


### PR DESCRIPTION
Related to https://github.com/gnosis/prediction-market-agent/issues/647, the fact that the errored function call isn't in the history is a feature of Microchain, not a bug. 

We could refactor it a bit, but atm I'm not convinced that it has to change, so I did a "2025 programmers move" -- just ask the LLM to do it for us! 😄 For our needs it seems to work fine. 

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/1ddf1faf-a658-49c9-b10a-6f81802a73cf)
