### PR TITLE
Bet on less markets

### DIFF
--- a/prediction_market_agent/agents/invalid_agent/deploy.py
+++ b/prediction_market_agent/agents/invalid_agent/deploy.py
@@ -18,7 +18,7 @@ class InvalidAgent(DeployableTraderAgent):
     Because on Omen, after market is resolved as invalid, outcome tokens are worth equally, which means one can be profitable by buying the cheapest token.
     Also the function to mark invalid questions is based on Omen-resolution rules."""
 
-    bet_on_n_markets_per_run: int = 10
+    bet_on_n_markets_per_run: int = 20
     supported_markets = [MarketType.OMEN]
 
     def verify_market(self, market_type: MarketType, market: AgentMarket) -> bool:

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -49,7 +49,7 @@ class DeployableTraderAgentER(DeployableTraderAgent):
 
 
 class DeployablePredictionProphetGPT4oAgent(DeployableTraderAgentER):
-    bet_on_n_markets_per_run = 20
+    bet_on_n_markets_per_run = 5
     agent: PredictionProphetAgent
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
@@ -90,9 +90,7 @@ class DeployablePredictionProphetGPT4oAgent(DeployableTraderAgentER):
 
 
 class DeployablePredictionProphetGPT4ominiAgent(DeployableTraderAgentER):
-    bet_on_n_markets_per_run = (
-        5  # 20 # Increase once `get_betting_strategy` is implemented.
-    )
+    bet_on_n_markets_per_run = 5
     agent: PredictionProphetAgent
 
     # TODO: Uncomment and configure after we get some historic bet data
@@ -501,9 +499,7 @@ class DeployablePredictionProphetClaude3OpusAgent(DeployableTraderAgentER):
 
 
 class DeployablePredictionProphetClaude35HaikuAgent(DeployableTraderAgentER):
-    bet_on_n_markets_per_run = (
-        5  # 20 # Increase once `get_betting_strategy` is implemented.
-    )
+    bet_on_n_markets_per_run = 5
     agent: PredictionProphetAgent
 
     # TODO: Uncomment and configure after we get some historic bet data
@@ -545,9 +541,7 @@ class DeployablePredictionProphetClaude35HaikuAgent(DeployableTraderAgentER):
 
 
 class DeployablePredictionProphetClaude35SonnetAgent(DeployableTraderAgentER):
-    bet_on_n_markets_per_run = (
-        5  # 20 # Increase once `get_betting_strategy` is implemented.
-    )
+    bet_on_n_markets_per_run = 5
     agent: PredictionProphetAgent
 
     # TODO: Uncomment and configure after we get some historic bet data

--- a/prediction_market_agent/agents/specialized_agent/deploy.py
+++ b/prediction_market_agent/agents/specialized_agent/deploy.py
@@ -34,7 +34,7 @@ class GetMarketCreatorsStalkerMarkets:
     bet_on_n_markets_per_run = MAX_AVAILABLE_MARKETS
     n_markets_to_fetch: int = MAX_AVAILABLE_MARKETS
     # These tends to be long-running markets, it's not interesting to bet on them too much.
-    same_market_trade_interval: TradeInterval = FixedInterval(timedelta(days=7))
+    same_market_trade_interval: TradeInterval = FixedInterval(timedelta(days=14))
     supported_markets: t.Sequence[MarketType] = [MarketType.OMEN]
 
     def get_markets(


### PR DESCRIPTION
In some agents, we had even 20 markets to bet on per run. However, due to a misconfiguration, it wasn't the case. Now when the misconfig is fixed, it seems like we are going to bet too much (we hit the Tavily limit already). So decreasing it a bit to see how it goes the next month. It might be still too much.