### PR TITLE
Add support of nested Safes in Safe Guard Agent

### DIFF
--- a/prediction_market_agent/agents/safe_guard_agent/safe_utils.py
+++ b/prediction_market_agent/agents/safe_guard_agent/safe_utils.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import tenacity
+from eth_account import Account
 from eth_account.messages import defunct_hash_message
 from prediction_market_agent_tooling.config import APIKeys, RPCConfig
 from prediction_market_agent_tooling.gtypes import ChecksumAddress, HexBytes
@@ -13,6 +14,7 @@ from safe_eth.safe.api.transaction_service_api.transaction_service_api import (
     TransactionServiceApi,
 )
 from safe_eth.safe.safe import Safe, SafeTx
+from safe_eth.safe.safe_signature import SafeSignature, SafeSignatureContract
 from web3 import Web3
 
 from prediction_market_agent.agents.safe_guard_agent.safe_api_models.detailed_transaction_info import (
@@ -38,11 +40,31 @@ def post_message(safe: Safe, message: str, api_keys: APIKeys) -> None:
     logger.info(f"Posting message to Safe {safe.address}.")
 
     message_hash = defunct_hash_message(text=message)
-    safe_message_hash = safe.get_message_hash(message_hash)  # type: ignore # type bug, it's iffed to work correctly inside the function.
-    owner_signature = api_keys.get_account().signHash(safe_message_hash)
+    target_safe_message_hash = safe.get_message_hash(message_hash)  # type: ignore # type bug, it's iffed to work correctly inside the function.
+
+    if api_keys.safe_address_checksum is not None:
+        # In the case we are posting message from another Safe.
+        # Based on https://github.com/safe-global/safe-eth-py/blob/v6.4.0/safe_eth/safe/tests/test_safe_signature.py#L184.
+        owner_safe_message_hash = get_safe(api_keys.safe_address_checksum).get_message_hash(message_hash)  # type: ignore # type bug, it's iffed to work correctly inside the function.
+        owner_safe_eoa_signature = api_keys.get_account().signHash(
+            owner_safe_message_hash
+        )["signature"]
+
+        owner_safe_signature = SafeSignatureContract.from_values(
+            api_keys.safe_address_checksum,
+            target_safe_message_hash,
+            message_hash,
+            owner_safe_eoa_signature,
+        )
+        signature = SafeSignature.export_signatures([owner_safe_signature])
+    else:
+        # Otherwise normal signature directly using EOA.
+        signature = api_keys.get_account().signHash(target_safe_message_hash)[
+            "signature"
+        ]
 
     api = TransactionServiceApi(network=EthereumNetwork(RPCConfig().chain_id))
-    api.post_message(safe.address, message, owner_signature.signature)
+    api.post_message(safe.address, message, signature)
 
 
 def reject_transaction(safe: Safe, tx: SafeTx, api_keys: APIKeys) -> None:
@@ -71,7 +93,15 @@ def sign_or_execute(safe: Safe, tx: SafeTx, api_keys: APIKeys) -> None:
     """
     Use this function to sign an existing transaction and automatically either execute it (if threshold is met), or to post your signature into the transaction in the queue.
     """
-    tx.sign(api_keys.bet_from_private_key.get_secret_value())
+
+    if api_keys.safe_address_checksum is not None:
+        _safe_sign(
+            tx,
+            api_keys.safe_address_checksum,
+            api_keys.bet_from_private_key.get_secret_value(),
+        )
+    else:
+        tx.sign(api_keys.bet_from_private_key.get_secret_value())
 
     if safe.retrieve_threshold() > len(tx.signatures):
         logger.info("Threshold not met yet, just adding a sign.")
@@ -93,8 +123,14 @@ def post_or_execute(safe: Safe, tx: SafeTx, api_keys: APIKeys) -> None:
             "Should be a fresh transaction. See `sign_or_execute` function for signing existing transaction."
         )
 
-    # Sign by our account.
-    tx.sign(api_keys.bet_from_private_key.get_secret_value())
+    if api_keys.safe_address_checksum is not None:
+        _safe_sign(
+            tx,
+            api_keys.safe_address_checksum,
+            api_keys.bet_from_private_key.get_secret_value(),
+        )
+    else:
+        tx.sign(api_keys.bet_from_private_key.get_secret_value())
 
     if safe.retrieve_threshold() > 1:
         logger.info(f"Safe requires multiple signers, posting to the queue.")
@@ -147,3 +183,37 @@ def _find_addresses_in_nested_structure(value: Any) -> set[ChecksumAddress]:
             # Ignore if it's not a valid address.
             pass
     return addresses
+
+
+def _safe_sign(
+    tx: SafeTx, owner_safe_address: ChecksumAddress, private_key: str
+) -> bytes:
+    """
+    TODO: This should be proposed into safe-eth-py as a method of SafeTx.
+    Based on https://github.com/safe-global/safe-eth-py/blob/v6.4.0/safe_eth/safe/tests/test_safe_signature.py#L210.
+
+    :param owner_safe_address:
+    :param private_key:
+    :return: Signature
+    """
+    account = Account.from_key(private_key)
+
+    owner_safe_message_hash = get_safe(owner_safe_address).get_message_hash(
+        tx.safe_tx_hash_preimage  # type: ignore # type bug, this is correct.
+    )
+    owner_safe_eoa_signature = account.signHash(owner_safe_message_hash)["signature"]
+    owner_safe_signature = SafeSignatureContract.from_values(
+        owner_safe_address,
+        tx.safe_tx_hash,
+        tx.safe_tx_hash_preimage,
+        owner_safe_eoa_signature,
+    )
+
+    current_signatures = SafeSignature.parse_signature(tx.signatures, tx.safe_tx_hash)
+    # Insert signature sorted
+    if owner_safe_address.lower() not in [x.lower() for x in tx.signers]:
+        tx.signatures = SafeSignature.export_signatures(
+            [owner_safe_signature, *current_signatures]
+        )
+
+    return tx.signatures

--- a/prediction_market_agent/agents/safe_guard_agent/safe_utils.py
+++ b/prediction_market_agent/agents/safe_guard_agent/safe_utils.py
@@ -229,12 +229,8 @@ def _abort_on_safe_owner_post(
     if api_keys.safe_address_checksum is None:
         return
 
-    if safe.retrieve_threshold() <= len(tx.signatures):
-        return
-
-    if api_keys.safe_address_checksum.lower() in [x.lower() for x in tx.signers]:
-        raise NotImplementedError(
-            f"""On the contract level, signing Safe transaction using another Safe (which is owner of the formet Safe) is supported.
+    raise NotImplementedError(
+        f"""On the contract level, signing Safe transaction using another Safe (which is owner of the formet Safe) is supported.
 That's why we are able to sign & execute the transaction right away in the case we have enough of signers.
 
 Unfortunatelly, support in Safe UI isn't implemented yet, and in the case that `SafeSignatureContract` is uploaded via TransactionServiceApi, 
@@ -246,4 +242,4 @@ For the details, see https://ethereum.stackexchange.com/questions/168598/queued-
 
 TODO: Remove this function once Safe UI supports this.
 """
-        )
+    )


### PR DESCRIPTION
These flows currently work:

- send a signed message 
- sign & execute transaction (ie if Safe Guard's signature is last required and it can execute the transaction immediately)
- sign & post transaction
- sign & uploaded transaction with the new signer

What's broken:

- Safe UI in case that we upload transaction with Safe sign, see https://ethereum.stackexchange.com/questions/168598/queued-transactions-in-safe-ui-giving-500-internal-server-error for details.

To reproduce the error:

1. Create a fresh Safe (really, create a new one; it will get broken!) with three required signers (your EOA, another Safe with threshold 1, where you have another EOA as signer and a third one that doesn't matter)
2. Send tiny xDai to it
3. Create a transaction to send even tiner xDai to somewhere else
4. Add the another Safe to your `.env` file along with the private key of its owner
5. Run following script:

```python
from pprint import pprint

from prediction_market_agent.agents.safe_guard_agent.safe_utils import (
    EthereumNetwork,
    HexBytes,
    SafeSignature,
    TransactionServiceApi,
)

multisig_id = "multisig id of that transaction"

pprint(
    validate_safe_transaction(
        multisig_id,
        do_sign_or_execution=True,
        do_reject=True,
        do_message=True,
    ).ok
)
```

6. Try to go to queued transactions in your Safe UI
