### PR TITLE
Update betting strategies based on benchmark

### DIFF
--- a/prediction_market_agent/agents/berlin1_agent/polysent_agent.py
+++ b/prediction_market_agent/agents/berlin1_agent/polysent_agent.py
@@ -37,7 +37,7 @@ class Berlin1PolySentAgent(DeployableTraderAgent):
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(APIKeys()),
             ),
         )

--- a/prediction_market_agent/agents/berlin2_agent/openai_search_agent_high.py
+++ b/prediction_market_agent/agents/berlin2_agent/openai_search_agent_high.py
@@ -20,7 +20,7 @@ class Berlin2OpenaiSearchAgentHigh(DeployableTraderAgent):
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(self.api_keys),
             ),
         )

--- a/prediction_market_agent/agents/berlin2_agent/openai_search_agent_variable.py
+++ b/prediction_market_agent/agents/berlin2_agent/openai_search_agent_variable.py
@@ -20,7 +20,7 @@ class Berlin2OpenaiSearchAgentVariable(DeployableTraderAgent):
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(self.api_keys),
             ),
         )

--- a/prediction_market_agent/agents/gptr_agent/deploy.py
+++ b/prediction_market_agent/agents/gptr_agent/deploy.py
@@ -35,7 +35,7 @@ class GPTRAgent(DeployableTraderAgent):
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(self.api_keys),
             ),
         )

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -161,7 +161,7 @@ class DeployablePredictionProphetGPT4oAgentCategorical(
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(self.api_keys),
             ),
         )
@@ -382,7 +382,7 @@ class DeployablePredictionProphetDeepSeekChat(DeployableTraderAgentProphetOpenRo
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(APIKeys()),
             ),
         )
@@ -663,7 +663,7 @@ class DeployablePredictionProphetGPTo1(DeployableTraderAgentER):
         return MultiCategoricalMaxAccuracyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(25),
+                max_=USD(5),
                 trading_balance=market.get_trade_balance(APIKeys()),
             ),
         )


### PR DESCRIPTION
# Agent Bet vs Simulated Bet Comparison

## DeployablePredictionProphetDeepSeekChat

Number of bets since 2025-06-02 04:41:18.267989+00:00: 462

240 bets do not have a corresponding trace (34.19%), ignoring them.

[1 / 6] Best value for DeployablePredictionProphetDeepSeekChat (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.999899197490755}, n train bets: 125, n test bets: 56): Training maximization: [596.3949162332002] Testing profit: 242.10 Original profit on Testing: 0.06 (testing dates 2025-06-09 to 2025-06-15)
[2 / 6] Best value for DeployablePredictionProphetDeepSeekChat (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.897560006539084}, n train bets: 181, n test bets: 69): Training maximization: [297.9787105497514, 241.9067726001395] Testing profit: 349.73 Original profit on Testing: 0.05 (testing dates 2025-06-16 to 2025-06-22)
[3 / 6] Best value for DeployablePredictionProphetDeepSeekChat (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.992078210441907}, n train bets: 250, n test bets: 63): Training maximization: [298.18080280961874, 181.56258472576695, 349.9592698644826] Testing profit: 266.83 Original profit on Testing: 0.04 (testing dates 2025-06-23 to 2025-06-29)
[4 / 6] Best value for DeployablePredictionProphetDeepSeekChat (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.985787767395053}, n train bets: 313, n test bets: 78): Training maximization: [298.1673994880685, 161.38115235194385, 291.6202126881132, 266.8195420273227] Testing profit: 378.87 Original profit on Testing: 0.76 (testing dates 2025-06-30 to 2025-07-06)
[5 / 6] Best value for DeployablePredictionProphetDeepSeekChat (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.971964923995028}, n train bets: 391, n test bets: 60): Training maximization: [298.1379233277376, 151.27872457043648, 262.43342648022156, 233.4421397264569, 378.8352512509888] Testing profit: 270.53 Original profit on Testing: 0.15 (testing dates 2025-07-08 to 2025-07-13)
[6 / 6] Best value for DeployablePredictionProphetDeepSeekChat (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.9874700714209}, n train bets: 451, n test bets: 11): Training maximization: [298.17098469396103, 145.2449177211946, 244.96379000982853, 213.4584092660463, 340.98766416342016, 270.5594579119197] Testing profit: 64.75 Original profit on Testing: 0.05 (testing dates 2025-07-14 to 2025-07-15)

Total simulated profit: 1572.811322528926
Total original profit: 1.1077865826345192


## DeployablePredictionProphetGPTo1

Number of bets since 2025-06-02 05:32:48.677720+00:00: 194

154 bets do not have a corresponding trace (44.25%), ignoring them.

[1 / 4] Best value for DeployablePredictionProphetGPTo1 (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.999540765138008}, n train bets: 71, n test bets: 31): Training maximization: [308.54319839571394] Testing profit: 151.73 Original profit on Testing: 0.07 (testing dates 2025-06-09 to 2025-06-15)
[2 / 4] Best value for DeployablePredictionProphetGPTo1 (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.994168334528222}, n train bets: 102, n test bets: 50): Training maximization: [154.2652831435522, 151.7288376657027] Testing profit: 226.08 Original profit on Testing: 0.10 (testing dates 2025-06-16 to 2025-06-22)
[3 / 4] Best value for DeployablePredictionProphetGPTo1 (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.974219884757243}, n train bets: 152, n test bets: 39): Training maximization: [154.24180777226505, 113.77993251948102, 226.04398382285538] Testing profit: 165.02 Original profit on Testing: 0.05 (testing dates 2025-06-23 to 2025-06-28)
[4 / 4] Best value for DeployablePredictionProphetGPTo1 (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.916036679563344}, n train bets: 191, n test bets: 2): Training maximization: [154.17312890121772, 101.09429952284486, 188.28951514238315, 164.9481409913393] Testing profit: 7.77 Original profit on Testing: -0.00 (testing dates 2025-07-02 to 2025-07-02)

Total simulated profit: 550.6043260646125
Total original profit: 0.2165735928706733


## AdvancedAgent

Number of bets since 2025-06-02 05:49:17.070909+00:00: 0

Only tiny amount of bets with traces found, skipping.

## Berlin1PolySentAgent

Number of bets since 2025-06-02 05:53:51.227543+00:00: 195

92 bets do not have a corresponding trace (32.06%), ignoring them.

[1 / 3] Best value for Berlin1PolySentAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.999927353188447}, n train bets: 50, n test bets: 91): Training maximization: [259.96604453799046] Testing profit: 533.07 Original profit on Testing: 0.03 (testing dates 2025-06-30 to 2025-07-06)
[2 / 3] Best value for Berlin1PolySentAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.86396819136889}, n train bets: 141, n test bets: 45): Training maximization: [129.866005501192, 532.6291919526745] Testing profit: 291.97 Original profit on Testing: -0.05 (testing dates 2025-07-08 to 2025-07-13)
[3 / 3] Best value for Berlin1PolySentAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.99048189653473}, n train bets: 186, n test bets: 9): Training maximization: [129.97493385319797, 399.7810738423533, 292.18114899009066] Testing profit: 51.93 Original profit on Testing: -0.00 (testing dates 2025-07-14 to 2025-07-14)

Total simulated profit: 876.9703611220921
Total original profit: -0.023682291313915436

## Berlin2OpenaiSearchAgentHigh

Number of bets since 2025-06-02 06:55:24.712619+00:00: 175

89 bets do not have a corresponding trace (33.71%), ignoring them.

[1 / 3] Best value for Berlin2OpenaiSearchAgentHigh (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.999684135392773}, n train bets: 49, n test bets: 82): Training maximization: [240.3206168442328] Testing profit: 404.92 Original profit on Testing: 0.04 (testing dates 2025-06-30 to 2025-07-06)
[2 / 3] Best value for Berlin2OpenaiSearchAgentHigh (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.80083573996109}, n train bets: 131, n test bets: 41): Training maximization: [119.99003613876036, 404.3529308983127] Testing profit: 166.15 Original profit on Testing: -0.02 (testing dates 2025-07-08 to 2025-07-13)
[3 / 3] Best value for Berlin2OpenaiSearchAgentHigh (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.982817009834914}, n train bets: 172, n test bets: 3): Training maximization: [120.1459683786189, 303.6551014382281, 166.38997930587598] Testing profit: 19.84 Original profit on Testing: -0.03 (testing dates 2025-07-14 to 2025-07-15)

Total simulated profit: 590.9118950854232
Total original profit: -0.014383489766332302

## Berlin2OpenaiSearchAgentVariable

Number of bets since 2025-06-02 13:37:03.356006+00:00: 200

98 bets do not have a corresponding trace (32.89%), ignoring them.

[1 / 3] Best value for Berlin2OpenaiSearchAgentVariable (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.99996259252107}, n train bets: 59, n test bets: 80): Training maximization: [267.4863466896285] Testing profit: 393.21 Original profit on Testing: 0.09 (testing dates 2025-06-30 to 2025-07-06)
[2 / 3] Best value for Berlin2OpenaiSearchAgentVariable (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.986499981605146}, n train bets: 139, n test bets: 50): Training maximization: [133.7304434406052, 393.1682336979204] Testing profit: 199.44 Original profit on Testing: 0.17 (testing dates 2025-07-08 to 2025-07-13)
[3 / 3] Best value for Berlin2OpenaiSearchAgentVariable (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.981254581721572}, n train bets: 189, n test bets: 11): Training maximization: [133.72547986638142, 294.86540458507955, 199.4336076802318] Testing profit: 47.17 Original profit on Testing: -0.02 (testing dates 2025-07-14 to 2025-07-15)

Total simulated profit: 639.8214413280854
Total original profit: 0.24019497472116236


## GPTRAgent

Number of bets since 2025-06-02 13:54:44.807807+00:00: 644

242 bets do not have a corresponding trace (27.31%), ignoring them.

[1 / 6] Best value for GPTRAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.99997735176688}, n train bets: 144, n test bets: 77): Training maximization: [584.1164101368987] Testing profit: 350.83 Original profit on Testing: 0.36 (testing dates 2025-06-09 to 2025-06-15)
[2 / 6] Best value for GPTRAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.937654549304693}, n train bets: 221, n test bets: 105): Training maximization: [291.91354669484485, 350.66911861792806] Testing profit: 452.67 Original profit on Testing: 0.27 (testing dates 2025-06-16 to 2025-06-22)
[3 / 6] Best value for GPTRAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.987006770656535}, n train bets: 326, n test bets: 74): Training maximization: [292.02815639149117, 263.09930134670054, 452.84544254232037] Testing profit: 295.83 Original profit on Testing: 0.12 (testing dates 2025-06-23 to 2025-06-29)
[4 / 6] Best value for GPTRAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.98420948040922}, n train bets: 400, n test bets: 113): Training maximization: [292.02167200851613, 233.86114418032702, 377.3630576269408, 295.8277971614835] Testing profit: 496.74 Original profit on Testing: 0.29 (testing dates 2025-06-30 to 2025-07-06)
[5 / 6] Best value for GPTRAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.956695031839477}, n train bets: 513, n test bets: 115): Training maximization: [291.95781597113944, 219.19957104159138, 339.5545676326476, 258.79238518809785, 496.63252012846874] Testing profit: 464.59 Original profit on Testing: 0.32 (testing dates 2025-07-07 to 2025-07-13)
[6 / 6] Best value for GPTRAgent (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.99411643133284}, n train bets: 628, n test bets: 16): Training maximization: [292.04463093391394, 210.4906486473686, 317.00919127532615, 236.68095430782247, 447.0964652691458, 464.7327781554098] Testing profit: 73.45 Original profit on Testing: 0.09 (testing dates 2025-07-14 to 2025-07-15)

Total simulated profit: 2134.1239974454616
Total original profit: 1.446977819072284


## DeployablePredictionProphetGPT4oAgentCategorical

Number of bets since 2025-06-02 15:00:50.532447+00:00: 982

332 bets do not have a corresponding trace (25.27%), ignoring them.

[1 / 6] Best value for DeployablePredictionProphetGPT4oAgentCategorical (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.999890511985008}, n train bets: 235, n test bets: 128): Training maximization: [1073.0494879438486] Testing profit: 531.50 Original profit on Testing: 0.06 (testing dates 2025-06-09 to 2025-06-15)
[2 / 6] Best value for DeployablePredictionProphetGPT4oAgentCategorical (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.880989083637274}, n train bets: 363, n test bets: 163): Training maximization: [536.0432934310093, 530.9971464967506] Testing profit: 663.16 Original profit on Testing: -0.20 (testing dates 2025-06-16 to 2025-06-22)
[3 / 6] Best value for DeployablePredictionProphetGPT4oAgentCategorical (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.921280810580026}, n train bets: 526, n test bets: 102): Training maximization: [536.2069422170097, 398.37616513432476, 663.3722459633016] Testing profit: 435.60 Original profit on Testing: -0.13 (testing dates 2025-06-23 to 2025-06-28)
[4 / 6] Best value for DeployablePredictionProphetGPT4oAgentCategorical (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.9575534980569}, n train bets: 628, n test bets: 186): Training maximization: [536.3538271947624, 354.21451510546314, 552.9718593633736, 435.71933142634765] Testing profit: 870.68 Original profit on Testing: 2.28 (testing dates 2025-06-30 to 2025-07-06)
[5 / 6] Best value for DeployablePredictionProphetGPT4oAgentCategorical (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.999887075362242}, n train bets: 814, n test bets: 152): Training maximization: [536.5247301210114, 332.18777319822726, 497.84395640221703, 381.3788333182866, 870.9503355412988] Testing profit: 656.90 Original profit on Testing: 0.13 (testing dates 2025-07-07 to 2025-07-13)
[6 / 6] Best value for DeployablePredictionProphetGPT4oAgentCategorical (params: {'strategy_name': 'MultiCategoricalMaxAccuracyBettingStrategy', 'bet_amount': 24.99001831014336}, n train bets: 966, n test bets: 16): Training maximization: [536.4849398662137, 318.87530365785926, 464.6175733676737, 348.6627343914189, 783.7990564015928, 656.8473389304004] Testing profit: 78.81 Original profit on Testing: 0.13 (testing dates 2025-07-14 to 2025-07-15)

Total simulated profit: 3236.6447078772167
Total original profit: 2.2667259302154474

