### PR TITLE
New strategies

### DIFF
--- a/prediction_market_agent/agents/berlin1_agent/polysent_agent.py
+++ b/prediction_market_agent/agents/berlin1_agent/polysent_agent.py
@@ -9,7 +9,11 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_openai import ChatOpenAI
 from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.deploy.agent import DeployableTraderAgent
-from prediction_market_agent_tooling.gtypes import Probability
+from prediction_market_agent_tooling.deploy.betting_strategy import (
+    BettingStrategy,
+    SimpleCategoricalKellyBettingStrategy,
+)
+from prediction_market_agent_tooling.gtypes import USD, Probability
 from prediction_market_agent_tooling.loggers import logger
 from prediction_market_agent_tooling.markets.agent_market import AgentMarket
 from prediction_market_agent_tooling.markets.data_models import ProbabilisticAnswer
@@ -20,6 +24,8 @@ from prediction_prophet.functions.web_scrape import web_scrape
 from pydantic_ai.exceptions import UnexpectedModelBehavior
 from sklearn.isotonic import IsotonicRegression
 
+from prediction_market_agent.agents.utils import get_maximum_possible_bet_amount
+
 
 class Berlin1PolySentAgent(DeployableTraderAgent):
     bet_on_n_markets_per_run = 2
@@ -27,15 +33,17 @@ class Berlin1PolySentAgent(DeployableTraderAgent):
 
     LOG_PATH: Path | None = None
 
-    # ! Even after optimizing, this doesn't seem to get profitable, keep commented to track tiny bets and test later.
-    # def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-    #     return CategoricalMaxAccuracyBettingStrategy(
-    #         max_position_amount=get_maximum_possible_bet_amount(
-    #             min_=USD(1),
-    #             max_=USD(5),
-    #             trading_balance=market.get_trade_balance(APIKeys()),
-    #         ),
-    #     )
+    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+        return SimpleCategoricalKellyBettingStrategy(
+            max_position_amount=get_maximum_possible_bet_amount(
+                min_=USD(0.1),
+                max_=USD(2.05),
+                trading_balance=market.get_trade_balance(APIKeys()),
+            ),
+            allow_multiple_bets=False,
+            allow_shorting=False,
+            multicategorical=False,
+        )
 
     def load(self) -> None:
         self.calibration_model = (

--- a/prediction_market_agent/agents/prophet_agent/deploy.py
+++ b/prediction_market_agent/agents/prophet_agent/deploy.py
@@ -363,13 +363,16 @@ class DeployablePredictionProphetGemini20Flash(DeployableTraderAgentProphetOpenR
     model = "google/gemini-2.0-flash-001"
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return FullBinaryKellyBettingStrategy(
+        return FullCategoricalKellyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
                 min_=USD(1),
-                max_=USD(6.5),
+                max_=USD(5.95),
                 trading_balance=market.get_trade_balance(APIKeys()),
             ),
-            max_price_impact=0.85,
+            max_price_impact=1.38,
+            allow_multiple_bets=False,
+            allow_shorting=False,
+            multicategorical=False,
         )
 
 
@@ -411,15 +414,16 @@ class DeployablePredictionProphetGPT4ominiAgent(DeployableTraderAgentER):
     bet_on_n_markets_per_run = 4
     agent: PredictionProphetAgent
 
-    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return FullBinaryKellyBettingStrategy(
-            max_position_amount=get_maximum_possible_bet_amount(
-                min_=USD(1),
-                max_=USD(3.5),
-                trading_balance=market.get_trade_balance(APIKeys()),
-            ),
-            max_price_impact=0.86,
-        )
+    # ! Even after optimizing, this doesn't seem to get profitable, keep commented to track tiny bets and test later. See the PR
+    # def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+    #     return FullBinaryKellyBettingStrategy(
+    #         max_position_amount=get_maximum_possible_bet_amount(
+    #             min_=USD(0.1),
+    #             max_=USD(2.88),
+    #             trading_balance=market.get_trade_balance(APIKeys()),
+    #         ),
+    #         max_price_impact=1.483,
+    #     )
 
     def load(self) -> None:
         super().load()
@@ -486,15 +490,16 @@ class DeployablePredictionProphetGPT4oAgentNewMarketTrader(
 class DeployablePredictionProphetGPT4TurboPreviewAgent(DeployableTraderAgentER):
     agent: PredictionProphetAgent
 
-    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return FullBinaryKellyBettingStrategy(
-            max_position_amount=get_maximum_possible_bet_amount(
-                min_=USD(1),
-                max_=USD(5),
-                trading_balance=market.get_trade_balance(APIKeys()),
-            ),
-            max_price_impact=0.5,
-        )
+    # ! Even after optimizing, this doesn't seem to get profitable, keep commented to track tiny bets and test later. See the PR
+    # def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+    #     return FullBinaryKellyBettingStrategy(
+    #         max_position_amount=get_maximum_possible_bet_amount(
+    #             min_=USD(0.1),
+    #             max_=USD(10),
+    #             trading_balance=market.get_trade_balance(APIKeys()),
+    #         ),
+    #         max_price_impact=0.014097885153547948,
+    #     )
 
     def load(self) -> None:
         super().load()
@@ -563,13 +568,16 @@ class DeployableOlasEmbeddingOAAgent(DeployableTraderAgentER):
     agent: OlasAgent
 
     def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return FullBinaryKellyBettingStrategy(
+        return FullCategoricalKellyBettingStrategy(
             max_position_amount=get_maximum_possible_bet_amount(
-                min_=USD(5),
-                max_=USD(25),
+                min_=USD(0.1),
+                max_=USD(6),
                 trading_balance=market.get_trade_balance(APIKeys()),
             ),
-            max_price_impact=0.5,
+            max_price_impact=0.7333271417580082,
+            allow_multiple_bets=False,
+            allow_shorting=False,
+            multicategorical=False,
         )
 
     def load(self) -> None:

--- a/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
+++ b/prediction_market_agent/agents/think_thoroughly_agent/deploy.py
@@ -56,19 +56,20 @@ class DeployableThinkThoroughlyAgent(DeployableThinkThoroughlyAgentBase):
 class DeployableThinkThoroughlyProphetResearchAgent(DeployableThinkThoroughlyAgentBase):
     agent_class = ThinkThoroughlyWithPredictionProphetResearch
 
-    def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
-        return (
-            FullBinaryKellyBettingStrategy(
-                max_position_amount=get_maximum_possible_bet_amount(
-                    min_=USD(1),
-                    max_=USD(5),
-                    trading_balance=market.get_trade_balance(APIKeys()),
-                ),
-                max_price_impact=0.4,
-            )
-            if isinstance(market, OmenAgentMarket)
-            else super().get_betting_strategy(market)
-        )  # Default to parent's tiny bet on other market types, as full kely isn't implemented properly yet. TODO: https://github.com/gnosis/prediction-market-agent-tooling/issues/830
+    # ! Even after optimizing, this doesn't seem to get profitable, keep commented to track tiny bets and test later. See the PR
+    # def get_betting_strategy(self, market: AgentMarket) -> BettingStrategy:
+    #     return (
+    #         FullBinaryKellyBettingStrategy(
+    #             max_position_amount=get_maximum_possible_bet_amount(
+    #                 min_=USD(1),
+    #                 max_=USD(5),
+    #                 trading_balance=market.get_trade_balance(APIKeys()),
+    #             ),
+    #             max_price_impact=0.4,
+    #         )
+    #         if isinstance(market, OmenAgentMarket)
+    #         else super().get_betting_strategy(market)
+    #     )  # Default to parent's tiny bet on other market types, as full kely isn't implemented properly yet. TODO: https://github.com/gnosis/prediction-market-agent-tooling/issues/830
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
TODO: Check profits in 1 month, have a slack reminder already ✅ 

Details:

## Berlin1PolySentAgent --> significantly better, changed to this one

Number of bets since 2025-05-14 00:00:00+00:00: 392

139 bets do not have a corresponding trace (26.18%), ignoring them.

Early stopping detected. No improvement at current_trial_number=513, after early_stopping_rounds=500.
[3 / 5] Best value for Berlin1PolySentAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 1.1433268859524697}, n train bets: 186, n test bets: 101): Training maximization: [0.03796308050481241, 1.3076385476108756, -0.8721291401200706] (no. 13)Testing profit: 1.04 Original profit on Testing: 0.10 (testing dates 2025-07-14 to 2025-07-20)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[4 / 5] Best value for Berlin1PolySentAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 0.30368390742465695}, n train bets: 287, n test bets: 64): Training maximization: [0.03592717092581243, 0.35481798912252227, -0.18009400039917337, 0.3331479077965595] (no. 0)Testing profit: -0.55 Original profit on Testing: -12.52 (testing dates 2025-07-21 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=1104, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[5 / 5] Best value for Berlin1PolySentAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 2.0555078037203436}, n train bets: 351, n test bets: 41): Training maximization: [-0.07147953645097307, 1.716890162959974, -1.257678388562422, 1.3007395290135841, -4.139983979876001] (no. 0)Testing profit: 1.55 Original profit on Testing: 0.06 (testing dates 2025-08-07 to 2025-08-10)

Total simulated profit: 2.0492113140318997
Total original profit: -12.35661925878349

## Berlin2OpenaiSearchAgentHigh --> significantly better, changed to this one

Number of bets since 2025-05-14 00:00:00+00:00: 371

136 bets do not have a corresponding trace (26.82%), ignoring them.

Early stopping detected. No improvement at current_trial_number=513, after early_stopping_rounds=500.
[3 / 5] Best value for Berlin2OpenaiSearchAgentHigh (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 3.026320580014885}, n train bets: 172, n test bets: 100): Training maximization: [3.712900195089352, 5.1629559873453985, 0.13082959994605603] (no. 13)Testing profit: 5.92 Original profit on Testing: 0.17 (testing dates 2025-07-14 to 2025-07-20)
Early stopping detected. No improvement at current_trial_number=503, after early_stopping_rounds=500.
[4 / 5] Best value for Berlin2OpenaiSearchAgentHigh (params: {'strategy_name': 'FullCategoricalKellyBettingStrategy', 'bet_amount': 3.267067070516637, 'max_price_impact': 0.9637813270295248}, n train bets: 272, n test bets: 58): Training maximization: [3.860503441229908, 4.640151959069243, -0.002585643189619568, 5.9607740982985975] (no. 3)Testing profit: -2.06 Original profit on Testing: -10.08 (testing dates 2025-07-21 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=711, after early_stopping_rounds=500.
  !!! Best value on this testing set: 0.06
Early stopping detected. No improvement at current_trial_number=501, after early_stopping_rounds=500.
[5 / 5] Best value for Berlin2OpenaiSearchAgentHigh (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 3.3203939346866083}, n train bets: 330, n test bets: 41): Training maximization: [3.920733665003204, 4.37718220798599, -0.04723713738460633, 5.2195192207720025, -2.1794023877810025] (no. 1)Testing profit: 13.55 Original profit on Testing: 0.16 (testing dates 2025-08-07 to 2025-08-10)

Total simulated profit: 17.412988791553722
Total original profit: -9.75348325155751

## DeployableOlasEmbeddingOAAgent --> significantly better, changed to this one

Number of bets since 2025-05-14 00:00:00+00:00: 1153

549 bets do not have a corresponding trace (32.26%), ignoring them.

Early stopping detected. No improvement at current_trial_number=501, after early_stopping_rounds=500.
[9 / 11] Best value for DeployableOlasEmbeddingOAAgent (params: {'strategy_name': 'FullCategoricalKellyBettingStrategy', 'bet_amount': 15.876885099022328, 'max_price_impact': 0.6614626630808517}, n train bets: 866, n test bets: 110): Training maximization: [17.07347330113132, 50.63250395352736, 17.439930948708593, 13.072001051006898, 37.47628836938157, -7.352804754792334, -32.212933492612414, 58.474556562548536, -0.8562834567259392] (no. 1)Testing profit: 17.55 Original profit on Testing: 17.53 (testing dates 2025-07-21 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[10 / 11] Best value for DeployableOlasEmbeddingOAAgent (params: {'strategy_name': 'FullCategoricalKellyBettingStrategy', 'bet_amount': 7.115554393398493, 'max_price_impact': 0.15308256894335454}, n train bets: 976, n test bets: 113): Training maximization: [14.602701974754694, 33.309874966540704, 19.983044667773033, 13.047963859802886, 29.0158505811236, 12.996436378234078, 3.7061714077428345, 37.21103868128166, 16.48934387555635, 26.076202762338788] (no. 0)Testing profit: 35.17 Original profit on Testing: 11.19 (testing dates 2025-07-28 to 2025-08-03)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[11 / 11] Best value for DeployableOlasEmbeddingOAAgent (params: {'strategy_name': 'FullCategoricalKellyBettingStrategy', 'bet_amount': 6.726269914232236, 'max_price_impact': 0.7333271417580082}, n train bets: 1089, n test bets: 64): Training maximization: [14.937018558922578, 35.84357143060056, 22.81578606682549, 12.58057499598524, 29.36204854577419, 15.39020054719412, -1.079030523108435, 37.20909678533083, 17.104329917637088, 26.676922990195372, 36.01268092291733] (no. 0)Testing profit: 10.90 Original profit on Testing: -17.28 (testing dates 2025-08-04 to 2025-08-10)

Total simulated profit: 63.61994427574221
Total original profit: 11.450169280006747

## DeployablePredictionProphetClaude35HaikuAgent --> won't change, still in loss, and currently it's configured for tiny bets

Number of bets since 2025-05-14 00:00:00+00:00: 182

287 bets do not have a corresponding trace (61.19%), ignoring them.

Early stopping detected. No improvement at current_trial_number=504, after early_stopping_rounds=500.
[7 / 9] Best value for DeployablePredictionProphetClaude35HaikuAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 4.3174579358627145}, n train bets: 165, n test bets: 10): Training maximization: [-5.314075630339315, -0.9116842497272486, -1.9618673593927856, -2.8273924201056375, 2.4543346227977425, -7.913682218743871, 0.43410735022696123] (no. 4)Testing profit: -1.34 Original profit on Testing: -7.05 (testing dates 2025-07-07 to 2025-07-13)
Early stopping detected. No improvement at current_trial_number=2125, after early_stopping_rounds=500.
  !!! Best value on this testing set: 0.89
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[8 / 9] Best value for DeployablePredictionProphetClaude35HaikuAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 3.495203770608507}, n train bets: 175, n test bets: 4): Training maximization: [-4.1733932247293595, -0.694143145358615, -1.3513807854135917, -2.141580450309547, 2.0058204834961573, -5.85713314411136, 1.062182454280714, -1.069384874525246] (no. 0)Testing profit: -0.54 Original profit on Testing: -0.56 (testing dates 2025-07-14 to 2025-07-18)
Early stopping detected. No improvement at current_trial_number=1128, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[9 / 9] Best value for DeployablePredictionProphetClaude35HaikuAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 5.144976299242774}, n train bets: 179, n test bets: 3): Training maximization: [-6.510013487903008, -1.0875563798875323, -2.4375508041641054, -3.139928565214585, 2.456886682166597, -8.533785210526638, -0.25650699277495503, -1.5110193873784603, -0.8013616370209469] (no. 0)Testing profit: 0.34 Original profit on Testing: 0.36 (testing dates 2025-07-30 to 2025-07-30)

Total simulated profit: -1.5326361701196956
Total original profit: -7.248180425306241

## DeployablePredictionProphetClaude35SonnetAgent --> better but not significantly, will keep the original one

Number of bets since 2025-05-20 00:00:00+00:00: 1191

444 bets do not have a corresponding trace (27.16%), ignoring them.

Early stopping detected. No improvement at current_trial_number=1002, after early_stopping_rounds=1000.
[10 / 12] Best value for DeployablePredictionProphetClaude35SonnetAgent (params: {'strategy_name': 'FullBinaryKellyBettingStrategy', 'bet_amount': 1.7727362728902296, 'max_price_impact': 0.19369264388998075}, n train bets: 926, n test bets: 119): Training maximization: [3.288919430302453, 9.57610845700863, 8.66207510409137, 1.9066751521107126, 0.7454190185391742, 8.60841578609292, 15.303864568334038, 3.727300881777546, 0.5044078222403783, -7.2034730449192805] (no. 2)Testing profit: 0.70 Original profit on Testing: -15.36 (testing dates 2025-07-28 to 2025-08-03)
Early stopping detected. No improvement at current_trial_number=1001, after early_stopping_rounds=1000.
[11 / 12] Best value for DeployablePredictionProphetClaude35SonnetAgent (params: {'strategy_name': 'FullBinaryKellyBettingStrategy', 'bet_amount': 17.24718132693871, 'max_price_impact': 0.18649979605784361}, n train bets: 1045, n test bets: 73): Training maximization: [8.01144152654109, 3.0615557202363792, 10.398228604835886, -0.5955032200973348, -5.904234702031486, 2.1057501865066497, 24.746748833563707, 1.7247328824278023, -10.649439283785322, -31.041537733535655, -12.992642885016568] (no. 1)Testing profit: 36.89 Original profit on Testing: 42.64 (testing dates 2025-08-04 to 2025-08-10)
Early stopping detected. No improvement at current_trial_number=1001, after early_stopping_rounds=1000.
[12 / 12] Best value for DeployablePredictionProphetClaude35SonnetAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 2.495036359675511}, n train bets: 1118, n test bets: 73): Training maximization: [4.809264475146612, 7.692138175726571, 7.440598002057729, 2.4895719645321273, 3.219221247692877, 2.210360757953595, 4.913432923857048, 8.646935950326734, 4.40864259605802, -7.219474917543258, -0.42811049887956887, 18.47214887450666] (no. 1)Testing profit: 2.75 Original profit on Testing: 2.52 (testing dates 2025-08-11 to 2025-08-16)

Total simulated profit: 40.34001188908528
Total original profit: 29.799798433202433

## DeployablePredictionProphetClaude3OpusAgent --> only one that is worse now :thinking:

Number of bets since 2025-05-21 00:00:00+00:00: 505

300 bets do not have a corresponding trace (37.27%), ignoring them.

Early stopping detected. No improvement at current_trial_number=1011, after early_stopping_rounds=1000.
[9 / 11] Best value for DeployablePredictionProphetClaude3OpusAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 1.3607591569150173}, n train bets: 447, n test bets: 8): Training maximization: [1.3350705087849386, 1.107884539104418, 0.5052434375415619, 0.3012031335836329, -0.45882986616849025, -0.14462792194569846, 0.2147397749610407, -0.013606768724948289, 0.6499033322510235] (no. 11)Testing profit: -0.37 Original profit on Testing: -0.26 (testing dates 2025-07-22 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=2176, after early_stopping_rounds=1000.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=1000, after early_stopping_rounds=1000.
[10 / 11] Best value for DeployablePredictionProphetClaude3OpusAgent (params: {'strategy_name': 'MaxExpectedValueBettingStrategy', 'bet_amount': 0.6274683621382051}, n train bets: 455, n test bets: 12): Training maximization: [2.992739755598751, 4.627310256668901, 0.9733423496293392, -0.4731691554893092, -1.718383463327404, -4.78724455687367, -2.4693901972307404, -2.8624263134463535, -0.10988166194348148, -1.7197619803006017] (no. 0)Testing profit: -3.43 Original profit on Testing: -0.43 (testing dates 2025-07-28 to 2025-08-01)
Early stopping detected. No improvement at current_trial_number=3244, after early_stopping_rounds=1000.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=1000, after early_stopping_rounds=1000.
[11 / 11] Best value for DeployablePredictionProphetClaude3OpusAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 0.7849023419407735}, n train bets: 467, n test bets: 4): Training maximization: [0.8043330012956715, 0.6768538494310603, 0.32627973158165935, 0.19620189878188554, -0.2000865746022777, -0.01374396765690792, 0.17056495585008846, -0.005671903304053868, 0.3629496735827972, -0.19454090298799573, -0.7482011632333521] (no. 0)Testing profit: -0.35 Original profit on Testing: -0.26 (testing dates 2025-08-08 to 2025-08-08)
Early stopping detected. No improvement at current_trial_number=2213, after early_stopping_rounds=1000.
  !!! Best value on this testing set: -0.00

Total simulated profit: -4.151855889714234
Total original profit: -0.9500633724175702

## DeployablePredictionProphetGPT4TurboPreviewAgent --> still in loss, configured to tiny bets

Number of bets since 2025-05-14 00:00:00+00:00: 414

391 bets do not have a corresponding trace (48.57%), ignoring them.

Early stopping detected. No improvement at current_trial_number=538, after early_stopping_rounds=500.
[5 / 7] Best value for DeployablePredictionProphetGPT4TurboPreviewAgent (params: {'strategy_name': 'FullBinaryKellyBettingStrategy', 'bet_amount': 0.6911138751653806, 'max_price_impact': 0.4875655117593387}, n train bets: 355, n test bets: 34): Training maximization: [0.4925417450978731, -2.7553491336436147, -4.181062443251395, -3.0360664168022193, -1.3352166227926063] (no. 38)Testing profit: -3.50 Original profit on Testing: -8.70 (testing dates 2025-06-23 to 2025-06-29)
Early stopping detected. No improvement at current_trial_number=554, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=526, after early_stopping_rounds=500.
[6 / 7] Best value for DeployablePredictionProphetGPT4TurboPreviewAgent (params: {'strategy_name': 'FullBinaryKellyBettingStrategy', 'bet_amount': 15.15593194989891, 'max_price_impact': 0.030148740017690426}, n train bets: 389, n test bets: 22): Training maximization: [2.5171728330165837, -7.76299609801198, -10.779021834938861, -6.226525147358792, -3.6391570382511347, -6.44492983664137] (no. 26)Testing profit: 1.85 Original profit on Testing: -1.57 (testing dates 2025-07-01 to 2025-07-05)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[7 / 7] Best value for DeployablePredictionProphetGPT4TurboPreviewAgent (params: {'strategy_name': 'FullBinaryKellyBettingStrategy', 'bet_amount': 10.114928746726191, 'max_price_impact': 0.014097885153547948}, n train bets: 411, n test bets: 3): Training maximization: [0.8586230757024164, -1.6105856990925482, -1.4182296748282213, -0.9782248621694141, -0.5656588221210435, -1.0408000776216872, 0.53624045265946] (no. 0)Testing profit: -0.34 Original profit on Testing: -1.34 (testing dates 2025-07-07 to 2025-07-13)
Early stopping detected. No improvement at current_trial_number=526, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00

Total simulated profit: -1.988649468847482
Total original profit: -11.610806351516338

## DeployablePredictionProphetGPT4oAgent --> this one is supposed to be the best one, didn't have a nerve to change it :smile:

Number of bets since 2025-05-14 00:00:00+00:00: 2118

831 bets do not have a corresponding trace (28.18%), ignoring them.

Early stopping detected. No improvement at current_trial_number=515, after early_stopping_rounds=500.
[9 / 11] Best value for DeployablePredictionProphetGPT4oAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 8.051178634827231}, n train bets: 1573, n test bets: 206): Training maximization: [7.842835302824747, 16.085141781021044, 19.115095888669117, 5.647063024538573, 37.8108207848068, 0.14767717648825965, 11.447109517310864, 25.888366758726853, 20.438019419812164] (no. 15)Testing profit: 41.41 Original profit on Testing: 15.33 (testing dates 2025-07-21 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[10 / 11] Best value for DeployablePredictionProphetGPT4oAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 4.651454525436135}, n train bets: 1779, n test bets: 222): Training maximization: [6.888134313777075, 14.925953743260722, 16.677996362535417, 6.481451361138621, 27.76130758898184, 6.835386592183449, 11.838673059276351, 19.894428856883916, 19.07765240749566, 33.16904349877205] (no. 0)Testing profit: 42.44 Original profit on Testing: -2.89 (testing dates 2025-07-28 to 2025-08-03)
Early stopping detected. No improvement at current_trial_number=502, after early_stopping_rounds=500.
[11 / 11] Best value for DeployablePredictionProphetGPT4oAgent (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 4.347143702661263}, n train bets: 2001, n test bets: 117): Training maximization: [6.661246514867136, 14.35156588303974, 15.846287009706636, 6.21613092548333, 25.765849341267405, 6.775984760329975, 11.122334457541456, 18.294226486561442, 17.70142994276126, 30.275919832385632, 40.6323857443206] (no. 2)Testing profit: 11.50 Original profit on Testing: -6.32 (testing dates 2025-08-04 to 2025-08-10)

Total simulated profit: 95.3423322248236
Total original profit: 6.114873519220536

## DeployablePredictionProphetGPT4ominiAgent --> changed to tiny bets

Number of bets since 2025-05-14 00:00:00+00:00: 2169

854 bets do not have a corresponding trace (28.25%), ignoring them.

Early stopping detected. No improvement at current_trial_number=501, after early_stopping_rounds=500.
[9 / 11] Best value for DeployablePredictionProphetGPT4ominiAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 6.8320835979577}, n train bets: 1619, n test bets: 212): Training maximization: [20.96647057127773, -10.327516731901955, -2.887608051415028, 12.680320353347623, -5.8490276674027974, -12.213148708228955, 15.927087858322958, -8.263132907613532, 8.030223699774645] (no. 1)Testing profit: -28.23 Original profit on Testing: -31.39 (testing dates 2025-07-21 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=1531, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[10 / 11] Best value for DeployablePredictionProphetGPT4ominiAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 0.060744303206928266}, n train bets: 1831, n test bets: 215): Training maximization: [0.313169834935852, 0.07448028896430668, 0.1401571548913601, 0.2280533775539874, 0.13561866698636826, 0.06651160749235067, 0.33498941723406067, 0.08726444424782319, 0.2594300298949498, -0.011039667467233553] (no. 0)Testing profit: 0.14 Original profit on Testing: -24.93 (testing dates 2025-07-28 to 2025-08-03)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[11 / 11] Best value for DeployablePredictionProphetGPT4ominiAgent (params: {'strategy_name': 'FullBinaryKellyBettingStrategy', 'bet_amount': 2.6872361272764804, 'max_price_impact': 1.4830169677870306}, n train bets: 2046, n test bets: 123): Training maximization: [9.918411307757005, -0.2376089361978983, -5.590979383046044, 17.330643881441112, -5.477335559473176, -8.194671675585708, 5.396096383317245, -25.326636202174463, -3.906261188654546, -29.678030666601277, -18.421646534488154] (no. 0)Testing profit: -9.61 Original profit on Testing: -10.06 (testing dates 2025-08-04 to 2025-08-10)
Early stopping detected. No improvement at current_trial_number=651, after early_stopping_rounds=500.
  !!! Best value on this testing set: 1.82

Total simulated profit: -37.702535106403154
Total original profit: -66.38221118760234

## DeployablePredictionProphetGPTo1MiniAgent --> kept the same

Number of bets since 2025-05-14 00:00:00+00:00: 375

360 bets do not have a corresponding trace (48.98%), ignoring them.

Early stopping detected. No improvement at current_trial_number=503, after early_stopping_rounds=500.
[6 / 8] Best value for DeployablePredictionProphetGPTo1MiniAgent (params: {'strategy_name': 'CategoricalMaxAccuracyBettingStrategy', 'bet_amount': 0.33443566327710506}, n train bets: 325, n test bets: 21): Training maximization: [0.33478550774323046, -1.007571357052733, -0.3736470550592289, -0.6942498635143661, 2.4311540407281744, -1.2044523263470805] (no. 3)Testing profit: 2.15 Original profit on Testing: 6.64 (testing dates 2025-06-30 to 2025-07-05)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[7 / 8] Best value for DeployablePredictionProphetGPTo1MiniAgent (params: {'strategy_name': 'CategoricalMaxAccuracyBettingStrategy', 'bet_amount': 2.1354849298031757}, n train bets: 346, n test bets: 7): Training maximization: [-1.2445717763880844, -13.354670373696917, -10.204586295644038, -11.229834458242365, 0.6421334581708725, -15.553672669090227, 8.912563069934855] (no. 0)Testing profit: -0.16 Original profit on Testing: -1.27 (testing dates 2025-07-07 to 2025-07-13)
Early stopping detected. No improvement at current_trial_number=847, after early_stopping_rounds=500.
  !!! Best value on this testing set: 0.13
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[8 / 8] Best value for DeployablePredictionProphetGPTo1MiniAgent (params: {'strategy_name': 'CategoricalMaxAccuracyBettingStrategy', 'bet_amount': 2.4041381236081762}, n train bets: 353, n test bets: 22): Training maximization: [-1.8340137199055122, -15.599583310761346, -12.067616565384302, -12.852162221863134, -0.8517935767330899, -17.3721039057743, 8.737806456934953, -0.2861405182897365] (no. 0)Testing profit: 6.28 Original profit on Testing: 1.42 (testing dates 2025-07-14 to 2025-07-20)

Total simulated profit: 8.26446028193569
Total original profit: 6.79096571986355

## DeployablePredictionProphetGemini20Flash --> changed to this one

Number of bets since 2025-05-14 00:00:00+00:00: 1053

495 bets do not have a corresponding trace (31.98%), ignoring them.

Early stopping detected. No improvement at current_trial_number=516, after early_stopping_rounds=500.
[9 / 11] Best value for DeployablePredictionProphetGemini20Flash (params: {'strategy_name': 'FullCategoricalKellyBettingStrategy', 'bet_amount': 8.389231349071702, 'max_price_impact': 0.5408336699423859}, n train bets: 867, n test bets: 81): Training maximization: [9.046128063865982, 5.3904031836684165, 11.76090595773118, 12.26814254133491, 25.301743047590882, 17.602077545125805, 6.074641618254596, 8.741997311026351, 26.262475145595634] (no. 16)Testing profit: 10.91 Original profit on Testing: -1.69 (testing dates 2025-07-21 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=502, after early_stopping_rounds=500.
[10 / 11] Best value for DeployablePredictionProphetGemini20Flash (params: {'strategy_name': 'SimpleCategoricalKellyBettingStrategy', 'bet_amount': 7.860237630253211}, n train bets: 948, n test bets: 79): Training maximization: [8.77420135384952, 5.280358910372929, 12.044479404044248, 12.191804994064208, 24.177829939873654, 16.786486692449255, 6.41227579072496, 8.125100860425944, 25.02274707554758, 11.303698879427582] (no. 2)Testing profit: 14.84 Original profit on Testing: -23.90 (testing dates 2025-07-28 to 2025-08-03)
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[11 / 11] Best value for DeployablePredictionProphetGemini20Flash (params: {'strategy_name': 'FullCategoricalKellyBettingStrategy', 'bet_amount': 5.953493607377086, 'max_price_impact': 1.383226643174437}, n train bets: 1027, n test bets: 26): Training maximization: [7.530809531200985, 4.827695720867378, 12.648466630789201, 12.041310870457284, 21.636667666571146, 17.253062779907804, 7.506160943769494, 6.901663439323483, 23.10934072290216, 11.200733026076433, 14.889708292366862] (no. 0)Testing profit: -0.46 Original profit on Testing: 1.16 (testing dates 2025-08-04 to 2025-08-09)
Early stopping detected. No improvement at current_trial_number=931, after early_stopping_rounds=500.
  !!! Best value on this testing set: 3.71

Total simulated profit: 25.290119549743796
Total original profit: -24.42946179960291

## DeployableThinkThoroughlyProphetResearchAgent --> changed to tiny bets

Number of bets since 2025-05-14 00:00:00+00:00: 166

247 bets do not have a corresponding trace (59.81%), ignoring them.

Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[8 / 10] Best value for DeployableThinkThoroughlyProphetResearchAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 0.5757750361815223}, n train bets: 126, n test bets: 13): Training maximization: [0.29047562321259746, 0.18582086473931536, 0.15294244822307937, -0.04204523337284677, 0.12998235144843864, 0.06132612400176311, 0.3112173910801659, 0.16447517967742484] (no. 0)Testing profit: -0.22 Original profit on Testing: -6.72 (testing dates 2025-07-24 to 2025-07-27)
Early stopping detected. No improvement at current_trial_number=647, after early_stopping_rounds=500.
  !!! Best value on this testing set: 0.00
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[9 / 10] Best value for DeployableThinkThoroughlyProphetResearchAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 3.507425551904007}, n train bets: 139, n test bets: 19): Training maximization: [1.0428609609460715, 0.41822783778224676, 0.6654924579528442, -0.46368652616525813, 0.42862202922414705, -0.046821796510630564, 1.5190987007642476, 0.7032539070583735, -1.5892272215743595] (no. 0)Testing profit: -1.44 Original profit on Testing: -9.92 (testing dates 2025-07-28 to 2025-08-03)
Early stopping detected. No improvement at current_trial_number=975, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00
Early stopping detected. No improvement at current_trial_number=500, after early_stopping_rounds=500.
[10 / 10] Best value for DeployableThinkThoroughlyProphetResearchAgent (params: {'strategy_name': 'SimpleBinaryKellyBettingStrategy', 'bet_amount': 1.8428900352886566}, n train bets: 158, n test bets: 7): Training maximization: [0.7480546440977041, 0.4087621847443494, 0.408305472418204, -0.1771739547146351, 0.29980773378736236, 0.08261464481786208, 0.8316393438590065, 0.4142201495789817, -0.7199565940500934, -0.5721835762141376] (no. 0)Testing profit: -0.32 Original profit on Testing: 7.06 (testing dates 2025-08-04 to 2025-08-09)
Early stopping detected. No improvement at current_trial_number=1167, after early_stopping_rounds=500.
  !!! Best value on this testing set: -0.00

Total simulated profit: -1.9768223456981762
Total original profit: -9.584233547022448
